### PR TITLE
build: added makefiles to build repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # cscope and ctags files
 cscope.*
 tags
+
+# dirs
+objs.*/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+#
+# Common top level values inheried by all makefiles
+#
+TOPDIR := $(shell git rev-parse --show-toplevel 2>/dev/null)
+ifeq ($(TOPDIR),)
+$(error "Not a git repository.")
+endif
+DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td
+TARGET_ARCH := $(shell uname -m)
+
+#
+# Helper command line variable for build debugging
+#
+ifeq ($(VERBOSE),2)
+Q :=
+else
+Q := @
+endif
+
+#
+# Variables populated by makesfiles at each level that includes Makefile.<rule>
+#
+PRODUCTS :=
+OBJDIR :=
+OBJ_SUBDIRS :=
+
+#
+# Define targets for directories at the next level
+#
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := firmware
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
+
+#
+# Common targets (after defining rules for targets at each level)
+#
+$(OBJ_SUBDIRS):
+	@mkdir -p $@
+
+#
+# Top-level targets that calls targets at lower levels
+#
+all: $(patsubst %,all.%,$(PRODUCTS))
+clean: $(patsubst %,clean.%,$(PRODUCTS))
+	@rm -rf $(OBJDIR)
+
+.DEFAULT_GOAL := all
+
+#
+# Include helper makefiles
+#
+include $(Makefile.buildenv)
+
+help:
+	@echo "Build Targets"
+	@echo "        all: build all firmware objects (default)"
+	@echo "      clean: remove all previously built firmware objects"
+	@echo "       help: show this message"
+	@echo
+	@$(MAKE) --no-print-directory buildenv_help
+

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,0 +1,99 @@
+#
+# @file: Makefile that defines absolute paths and macro definitions for
+#        the build system for the repo. A symlink to this file must
+#        exist at each directory level of this repo.
+#
+
+
+#
+# Use temporary variable to represent TOPDIR since this file maybe
+# included from anywhere in the directory tree. Since value of
+# TOPDIR is used to determine where this file was included from,
+# it may or may not be set. And paths of these makefiles must
+# always resolve.
+#
+_TOPDIR_ := $(shell git rev-parse --show-toplevel)
+Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
+Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
+
+#
+# Macro to include a sub-directory
+#
+define subdirs
+PRODIR := $(1)
+#
+# Undef variables before include of a "rule makefile" (e.g. Makefile.stm32)
+#
+
+#
+# Variables representing supported product build rules.
+#
+STM32_ELF :=
+
+
+#
+# Rules for targets "[all|clean].$(PRODUCT)" would need their own
+# copy of following variables.
+#
+PRODUCT :=
+CFLAGS :=
+LFLAGS :=
+
+include $(1)/Makefile
+endef
+
+
+#
+# Enlist all supported rules to help locate all the targets in a directory
+#
+ALL_RULES := STM32_ELF
+PROD_PATT := $(ALL_RULES:%=/^%/)
+PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
+
+
+#
+# Wrapper macro to "subdirs" macro. Depending upon which directory "$(MAKE)"
+# is invoked upon, this macro will either simply include subdirectories or
+# invoke appropriate targets from the $(TOPDIR).
+#
+define inc_subdir
+ifeq ($(TOPDIR),)
+
+ifeq ($(MAKECMDGOALS),)
+TARGETS := all
+else
+TARGETS := $(MAKECMDGOALS)
+endif
+
+PROD_NAME := $(shell find $(1) -name Makefile -exec awk '$(PROD_PATT){print $$3}' {} \+)
+PROD_TGTS :=
+$$(foreach TGT,$$(TARGETS), $$(foreach PROD,$$(PROD_NAME),$$(eval PROD_TGTS += $$(TGT).$$(PROD))))
+
+$$(TARGETS):
+	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(PROD_TGTS)
+else
+$$(foreach SUBDIR,$(2:%=$(1)%),$$(eval $$(call subdirs,$$(SUBDIR))))
+
+endif
+endef
+
+#
+# Wrapper macro to include "Makefile.<rule>".
+#
+define inc_rule
+ifeq ($(TOPDIR),)
+
+ifeq ($(MAKECMDGOALS),)
+TARGETS := all.$(2)
+else
+TARGETS := $(MAKECMDGOALS:%=%.$(2))
+$(MAKECMDGOALS): $$(TARGETS)
+endif
+
+$$(TARGETS):
+	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$@
+
+else
+include $(Makefile.$(1))
+endif
+endef

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -1,0 +1,88 @@
+ifdef STM32_ELF
+
+# $(info $(shell echo))
+# $(info -> PRODIR: $(PRODIR))
+# $(info -> H_DIRS: $(H_DIRS))
+# $(info -> C_SRCS: $(C_SRCS))
+# $(info -> S_SRCS: $(S_SRCS))
+
+CC := /usr/bin/arm-none-eabi-gcc
+OBJCOPY := /usr/bin/arm-none-eabi-objcopy
+
+# This file defines rules for targets: [all|clean].$(PRODUCT)
+PRODUCT := $(STM32_ELF)
+# For top Makefile
+PRODUCTS += $(PRODUCT)
+
+OBJDIR := objs.arm
+PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+
+ELF := $(PRODUCT_OBJDIR)/$(STM32_ELF).elf
+BIN := $(ELF:%.elf=%.bin)
+HEX := $(ELF:%.elf=%.hex)
+LD_MAP := $(ELF:%.elf=%.map)
+
+# $(info PRODIR: $(PRODIR))
+# $(info PRODUCT_OBJDIR: $(PRODUCT_OBJDIR))
+
+H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
+C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
+S_OBJS := $(S_SRCS:%.s=$(OBJDIR)/$(PRODIR)/%.o)
+LD_SRC := $(LD_SRC:%=$(PRODIR)/%)
+
+# $(info H_INCS: $(H_INCS))
+
+# For top Makefile
+OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS)))
+
+CFLAGS += -Wall -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb
+CFLAGS += $(H_INCS)
+CFLAGS += -DSTM32F401xE
+LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
+
+# $(info CFLAGS: $(CFLAGS))
+
+define C_OBJ_TGT
+$(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
+	@if [ "$(VERBOSE)" ]; then \
+		echo "Building $$< => $$@"; \
+	fi;
+	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@
+	@mv -f $$*.Td $$*.d && touch $$@
+
+include $(wildcard $(patsubst %,%.d,$(basename $(1))))
+endef
+$(foreach OBJFILE,$(C_OBJS),$(eval $(call C_OBJ_TGT,$(OBJFILE))))
+
+define S_OBJ_TGT
+$(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))
+	@if [ "$(VERBOSE)" ]; then \
+		echo "Building $$< => $$@"; \
+	fi;
+	$(Q)$$(CC) $$(CFLAGS) -c $$< -o $$@
+endef
+$(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))
+
+$(ELF): $(LD_SRC) $(C_OBJS) $(S_OBJS)
+	@echo "Creating $@"
+	$(Q)$(CC) $(LFLAGS) -T $^ -o $@
+
+$(BIN): $(ELF)
+	@echo "Creating $@"
+	$(Q)$(OBJCOPY) -Obinary $^ $@
+
+$(HEX): $(ELF)
+	@echo "Creating $@"
+	$(Q)$(OBJCOPY) -Oihex $^ $@
+
+all.$(PRODUCT): $(ELF) $(BIN) $(HEX)
+
+clean.$(PRODUCT):
+	@echo "Removing $(PRODUCT_OBJDIR)"
+	$(Q)rm -rf $(PRODUCT_OBJDIR)
+
+all.$(PRODUCT) clean.$(PRODUCT):: CFLAGS := $(CFLAGS)
+all.$(PRODUCT) clean.$(PRODUCT):: LFLAGS := $(LFLAGS)
+all.$(PRODUCT) clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+
+endif  # define STM32_ELF

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := nucleo
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/Makefile.defs
+++ b/firmware/Makefile.defs
@@ -1,0 +1,1 @@
+../Makefile.defs

--- a/firmware/nucleo/Lidar_Delivery/Makefile
+++ b/firmware/nucleo/Lidar_Delivery/Makefile
@@ -1,0 +1,10 @@
+STM32_ELF := lidar_delivery
+
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+H_DIRS := $(shell find $(THIS_DIR) -name "*.h" -exec dirname {} \+ 2>/dev/null | uniq | sed "s|$(THIS_DIR)||")
+C_SRCS := $(shell find $(THIS_DIR) -name "*.c" -printf "%P\n" 2>/dev/null | sed "s|^\./||")
+S_SRCS := $(shell find $(THIS_DIR) -name "*.s" -printf "%P\n" 2>/dev/null | sed "s|^\./||")
+LD_SRC := LinkerScript.ld
+
+include Makefile.defs
+$(eval $(call inc_rule,stm32,$(STM32_ELF)))

--- a/firmware/nucleo/Lidar_Delivery/Makefile.defs
+++ b/firmware/nucleo/Lidar_Delivery/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/firmware/nucleo/Makefile
+++ b/firmware/nucleo/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := Lidar_Delivery
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/nucleo/Makefile.defs
+++ b/firmware/nucleo/Makefile.defs
@@ -1,0 +1,1 @@
+../../Makefile.defs


### PR DESCRIPTION
Makefiles are intended to allow arbitrary directory structure for this repo. It only supports building a STM32 firmware for now. More rules can be added (e.g. build library or binaries) in future to provide a more complete solutions that involves STM32 firmware interacting with software stack on a host.

Not quite `Bazel` but motivation does come from it.