### PR TITLE
build: cleanup targets that create/removes buildenv shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,7 @@ TOPDIR := $(shell git rev-parse --show-toplevel 2>/dev/null)
 ifeq ($(TOPDIR),)
 $(error "Not a git repository.")
 endif
-DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td
 TARGET_ARCH := $(shell uname -m)
-
-#
-# Helper command line variable for build debugging
-#
-ifeq ($(VERBOSE),2)
-Q :=
-else
-Q := @
-endif
 
 #
 # Variables populated by makesfiles at each level that includes Makefile.<rule>
@@ -58,5 +48,4 @@ help:
 	@echo "      clean: remove all previously built firmware objects"
 	@echo "       help: show this message"
 	@echo
-	@$(MAKE) --no-print-directory buildenv_help
-
+	@$(MAKE) --no-print-directory help.buildenv

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,8 +13,23 @@
 # always resolve.
 #
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
-Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
+Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
+Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
+
+#
+# Common constants
+#
+DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td
+
+#
+# Helper command line variable for build debugging
+#
+ifeq ($(VERBOSE),2)
+Q :=
+else
+Q := @
+endif
 
 #
 # Macro to include a sub-directory
@@ -36,6 +51,8 @@ STM32_ELF :=
 # copy of following variables.
 #
 PRODUCT :=
+CC :=
+OBJCOPY :=
 CFLAGS :=
 LFLAGS :=
 

--- a/build/Makefile.arm
+++ b/build/Makefile.arm
@@ -1,0 +1,7 @@
+ifneq ($(TARGET_ARCH),arm)
+CC := /usr/bin/arm-none-eabi-gcc
+OBJCOPY := /usr/bin/arm-none-eabi-objcopy
+else
+CC := gcc
+OBJCOPY := objcopy
+endif

--- a/build/Makefile.buildenv
+++ b/build/Makefile.buildenv
@@ -1,6 +1,6 @@
-DOCKERFILE := build/Dockerfile.buildenv
+DOCKERFILE := $(_TOPDIR_)/build/Dockerfile.buildenv
 IMAGE_NAME := stm32_buildenv
-CONTAINER_NAME := $(IMAGE_NAME)$(subst /,.,$(subst $(HOME),,$(TOPDIR)))
+CONTAINER_NAME := $(IMAGE_NAME)$(subst /,.,$(subst $(HOME),,$(_TOPDIR_)))
 DOCKER_CMD := DOCKER_BUILDKIT=1 docker
 
 THIS_USER := $(shell whoami)
@@ -10,36 +10,60 @@ THIS_GID := $(shell id -g)
 DOCKER_SOCKET := /var/run/docker.sock
 DOCKER_GID := $(shell stat -c '%g' $(DOCKER_SOCKET) 2>/dev/null)
 
-build:
-	$(DOCKER_CMD) build --build-arg USER=$(THIS_USER) \
-		--build-arg GROUP=$(THIS_GROUP) \
-		--build-arg UID=$(THIS_UID) \
-		--build-arg GID=$(THIS_GID) \
-		--build-arg DOCKER_GID=$(DOCKER_GID) \
-		-t $(IMAGE_NAME) -f $(DOCKERFILE) .
+define buildenv_image
+	if [ "$(1)" = "clean" ]; then \
+		$(DOCKER_CMD) image rm -f $(IMAGE_NAME) >/dev/null 2>&1 || true; \
+	elif [ -z "$$($(DOCKER_CMD) images -q $(IMAGE_NAME) 2>/dev/null)" ]; then \
+		$(DOCKER_CMD) build --build-arg USER=$(THIS_USER) \
+			--build-arg GROUP=$(THIS_GROUP) \
+			--build-arg UID=$(THIS_UID) \
+			--build-arg GID=$(THIS_GID) \
+			--build-arg DOCKER_GID=$(DOCKER_GID) \
+			-t $(IMAGE_NAME) -f $(DOCKERFILE) .; \
+	fi;
+endef
 
-clean_build: stop
-	$(DOCKER_CMD) image rm -f $(IMAGE_NAME) >/dev/null 2>&1 || true
+define buildenv_container
+	if [ "$(1)" = "stop" ]; then \
+		$(DOCKER_CMD) stop $(CONTAINER_NAME) >/dev/null 2>&1 || true; \
+	elif [ "$$($(DOCKER_CMD) ps --filter name=$(CONTAINER_NAME) --format "{{.Names}}")" != "$(CONTAINER_NAME)" ]; then \
+		$(DOCKER_CMD) run --name $(CONTAINER_NAME) --rm -d --privileged --net=host \
+			-u $(THIS_USER) \
+			-e USER=$(THIS_USER) -e DISPLAY=$(DISPLAY) -e BUILDENV_SHELL=true \
+			-v /tmp/.X11-unix/:/tmp/.X11-unix -v "$(PWD):$(PWD)" -v $(DOCKER_SOCKET):$(DOCKER_SOCKET) -v /tmp:/tmp \
+			-w $(PWD) -it $(IMAGE_NAME); \
+	fi;
+endef
 
-start:
-	$(DOCKER_CMD) run --name $(CONTAINER_NAME) --rm -d --privileged --net=host \
-		-u $(THIS_USER) \
-		-e USER=$(THIS_USER) -e DISPLAY=$(DISPLAY) \
-		-v /tmp/.X11-unix/:/tmp/.X11-unix -v "$(PWD):$(PWD)" -v $(DOCKER_SOCKET):$(DOCKER_SOCKET) -v /tmp:/tmp \
-		-w $(PWD) -it $(IMAGE_NAME)
+define buildenv_shell
+	if [ "$(BUILDENV_SHELL)" = "true" ]; then \
+		echo "Already inside buildenv-shell."; \
+	else \
+		$(DOCKER_CMD) exec -it $(CONTAINER_NAME) /bin/bash; \
+	fi;
+endef
 
-stop:
-	$(DOCKER_CMD) stop $(CONTAINER_NAME) >/dev/null 2>&1 || true
+mkenv:
+	@$(call buildenv_image)
 
-run:
-	$(DOCKER_CMD) exec -it $(CONTAINER_NAME) /bin/bash
+startenv: mkenv
+	@$(call buildenv_container)
 
-buildenv_help:
+stopenv:
+	@$(call buildenv_container,stop)
+
+env: startenv
+	@$(call buildenv_shell)
+
+rmenv: stopenv
+	@$(call buildenv_image,clean)
+
+#
+# Advertise only high-level targets
+#
+help.buildenv:
 	@echo "Build environment targets"
-	@echo "      build: Create docker image (\"$(IMAGE_NAME)\") representing the build-environment for STM projects"
-	@echo "clean_build: Remove existing build-environment image"
-	@echo "      start: Start a build-environment image container for this workspace (aka \"buildenv shell\")"
-	@echo "       stop: Stop the currently running \"buildenv shell\""
-	@echo "        run: Run a new \"buildenv shell\" for this workspace"
+	@echo "   env: Run a \"buildenv shell\" for this workspace"
+	@echo " rmenv: Remove existing build-environment (must exit \"buildenv shell\" first)"
 
-.PHONY: start stop run build
+.PHONY: mkenv stopenv

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -1,13 +1,7 @@
 ifdef STM32_ELF
 
-# $(info $(shell echo))
-# $(info -> PRODIR: $(PRODIR))
-# $(info -> H_DIRS: $(H_DIRS))
-# $(info -> C_SRCS: $(C_SRCS))
-# $(info -> S_SRCS: $(S_SRCS))
-
-CC := /usr/bin/arm-none-eabi-gcc
-OBJCOPY := /usr/bin/arm-none-eabi-objcopy
+# Override to use arm-none-eabi-gcc
+include $(Makefile.arm)
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 PRODUCT := $(STM32_ELF)
@@ -22,15 +16,10 @@ BIN := $(ELF:%.elf=%.bin)
 HEX := $(ELF:%.elf=%.hex)
 LD_MAP := $(ELF:%.elf=%.map)
 
-# $(info PRODIR: $(PRODIR))
-# $(info PRODUCT_OBJDIR: $(PRODUCT_OBJDIR))
-
 H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
 C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
 S_OBJS := $(S_SRCS:%.s=$(OBJDIR)/$(PRODIR)/%.o)
 LD_SRC := $(LD_SRC:%=$(PRODIR)/%)
-
-# $(info H_INCS: $(H_INCS))
 
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS)))
@@ -39,8 +28,6 @@ CFLAGS += -Wall -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb
 CFLAGS += $(H_INCS)
 CFLAGS += -DSTM32F401xE
 LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
-
-# $(info CFLAGS: $(CFLAGS))
 
 define C_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
@@ -81,6 +68,8 @@ clean.$(PRODUCT):
 	@echo "Removing $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
+all.$(PRODUCT) clean.$(PRODUCT):: CC := $(CC)
+all.$(PRODUCT) clean.$(PRODUCT):: OBJCOPY := $(OBJCOPY)
 all.$(PRODUCT) clean.$(PRODUCT):: CFLAGS := $(CFLAGS)
 all.$(PRODUCT) clean.$(PRODUCT):: LFLAGS := $(LFLAGS)
 all.$(PRODUCT) clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)


### PR DESCRIPTION
For better handling of image creating and deletion. Also simplifies `make` targets that are user facing.

Made other minor fixes and cleanups [unrelated to buildenv makefiles].