### PR TITLE
build: added support for C library, C binary and aarch64 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ TARGET_ARCH := $(shell uname -m)
 # Variables populated by makesfiles at each level that includes Makefile.<rule>
 #
 PRODUCTS :=
-OBJDIR :=
+OBJDIRS :=
 OBJ_SUBDIRS :=
 
 #
 # Define targets for directories at the next level
 #
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := firmware
+SUBDIRS := firmware libs
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
 
@@ -33,7 +33,7 @@ $(OBJ_SUBDIRS):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 clean: $(patsubst %,clean.%,$(PRODUCTS))
-	@rm -rf $(OBJDIR)
+	@rm -rf $(OBJDIRS)
 
 .DEFAULT_GOAL := all
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OBJ_SUBDIRS :=
 # Define targets for directories at the next level
 #
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := firmware libs
+SUBDIRS := firmware libs cmds
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
 
@@ -33,7 +33,7 @@ $(OBJ_SUBDIRS):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 clean: $(patsubst %,clean.%,$(PRODUCTS))
-	@rm -rf $(OBJDIRS)
+	@rm -rf $(sort $(OBJDIRS))
 
 .DEFAULT_GOAL := all
 

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,21 @@ ifeq ($(TOPDIR),)
 $(error "Not a git repository.")
 endif
 TARGET_ARCH := $(shell uname -m)
+SUPPORTED_ARCHS := aarch64 x86_64
+OBJDIR_PREFIX := objs.
+
+#
+# Validate cross-compile arch when specified from cmdline
+#
+ARCH ?= $(TARGET_ARCH)
+ifeq ($(filter $(ARCH),$(SUPPORTED_ARCHS)),)
+$(error Error: Unsupported ARCH: "$(ARCH)" (Supported: $(SUPPORTED_ARCHS) | Default: $(TARGET_ARCH)))
+endif
 
 #
 # Variables populated by makesfiles at each level that includes Makefile.<rule>
 #
 PRODUCTS :=
-OBJDIRS :=
 OBJ_SUBDIRS :=
 
 #
@@ -33,7 +42,7 @@ $(OBJ_SUBDIRS):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 clean: $(patsubst %,clean.%,$(PRODUCTS))
-	@rm -rf $(sort $(OBJDIRS))
+	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 .DEFAULT_GOAL := all
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,10 +13,11 @@
 # always resolve.
 #
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
-Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
+Makefile.aarch64 := $(_TOPDIR_)/build/Makefile.aarch64
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
 Makefile.cbin := $(_TOPDIR_)/build/Makefile.cbin
 Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
+Makefile.firmware := $(_TOPDIR_)/build/Makefile.firmware
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.x86_64 := $(_TOPDIR_)/build/Makefile.x86_64
 
@@ -39,6 +40,7 @@ endif
 #
 define subdirs
 PRODIR := $(1)
+OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
 #
 # Undef variables before include of a "rule makefile" (e.g. Makefile.stm32)
 #
@@ -81,7 +83,7 @@ PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 #
 #
 define inc_subdir
-include $(Makefile.$(TARGET_ARCH))
+include $(Makefile.$(ARCH))
 
 ifeq ($(TOPDIR),)
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -15,6 +15,7 @@
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
 Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
+Makefile.cbin := $(_TOPDIR_)/build/Makefile.cbin
 Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.x86_64 := $(_TOPDIR_)/build/Makefile.x86_64
@@ -47,6 +48,7 @@ PRODIR := $(1)
 #
 STM32_ELF :=
 C_LIB :=
+C_BIN :=
 
 
 #
@@ -64,7 +66,7 @@ endef
 #
 # Enlist all supported rules to help locate all the targets in a directory
 #
-ALL_RULES := STM32_ELF C_LIB
+ALL_RULES := STM32_ELF C_LIB C_BIN
 PROD_PATT := $(ALL_RULES:%=/^%/)
 PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -15,7 +15,9 @@
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
 Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
+Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
+Makefile.x86_64 := $(_TOPDIR_)/build/Makefile.x86_64
 
 #
 # Common constants
@@ -44,6 +46,7 @@ PRODIR := $(1)
 # Variables representing supported product build rules.
 #
 STM32_ELF :=
+C_LIB :=
 
 
 #
@@ -51,8 +54,6 @@ STM32_ELF :=
 # copy of following variables.
 #
 PRODUCT :=
-CC :=
-OBJCOPY :=
 CFLAGS :=
 LFLAGS :=
 
@@ -63,7 +64,7 @@ endef
 #
 # Enlist all supported rules to help locate all the targets in a directory
 #
-ALL_RULES := STM32_ELF
+ALL_RULES := STM32_ELF C_LIB
 PROD_PATT := $(ALL_RULES:%=/^%/)
 PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 
@@ -73,7 +74,13 @@ PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 # is invoked upon, this macro will either simply include subdirectories or
 # invoke appropriate targets from the $(TOPDIR).
 #
+# Initializes $(CC) for the target architecture.
+# May get overriden by a Makefile.<rule> (during $(call inc_rule,<rule>,<product>))
+#
+#
 define inc_subdir
+include $(Makefile.$(TARGET_ARCH))
+
 ifeq ($(TOPDIR),)
 
 ifeq ($(MAKECMDGOALS),)
@@ -113,4 +120,19 @@ $$(TARGETS):
 else
 include $(Makefile.$(1))
 endif
+endef
+
+define C_OBJ_TGT
+$(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
+	@if [ "$(VERBOSE)" ]; then \
+		echo "Building $$< => $$@"; \
+	fi;
+	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@
+	@mv -f $$*.Td $$*.d && touch $$@
+
+include $(wildcard $(patsubst %,%.d,$(basename $(1))))
+endef
+
+define add_c_obj_tgts
+$$(foreach OBJFILE,$(1),$$(eval $$(call C_OBJ_TGT,$$(OBJFILE))))
 endef

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -7,6 +7,7 @@ RUN apt-get update && \
         binutils-arm-none-eabi \
         cmake \
         docker.io \
+	gcc-aarch64-linux-gnu \
         gcc-arm-none-eabi \
         libusb-1.0 \
         make \

--- a/build/Makefile.aarch64
+++ b/build/Makefile.aarch64
@@ -1,0 +1,8 @@
+ifneq ($(TARGET_ARCH),aarch64)
+CROSS_COMPILE_PREFIX := /usr/bin/aarch64-linux-gnu-
+else
+CROSS_COMPILE_PREFIX :=
+endif
+CC := $(CROSS_COMPILE_PREFIX)gcc
+AR := $(CROSS_COMPILE_PREFIX)ar
+OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.arm
+++ b/build/Makefile.arm
@@ -1,9 +1,0 @@
-ifneq ($(TARGET_ARCH),arm)
-CC := /usr/bin/arm-none-eabi-gcc
-AR := /usr/bin/arm-none-eabi-ar
-OBJCOPY := /usr/bin/arm-none-eabi-objcopy
-else
-CC := gcc
-AR := ar
-OBJCOPY := objcopy
-endif

--- a/build/Makefile.arm
+++ b/build/Makefile.arm
@@ -1,7 +1,9 @@
 ifneq ($(TARGET_ARCH),arm)
 CC := /usr/bin/arm-none-eabi-gcc
+AR := /usr/bin/arm-none-eabi-ar
 OBJCOPY := /usr/bin/arm-none-eabi-objcopy
 else
 CC := gcc
+AR := ar
 OBJCOPY := objcopy
 endif

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -1,7 +1,7 @@
-ifdef C_LIB
+ifdef C_BIN
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(C_LIB)
+PRODUCT := $(C_BIN)
 # For top Makefile
 PRODUCTS += $(PRODUCT)
 
@@ -10,17 +10,15 @@ PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 # For top Makefile
 OBJDIRS += $(OBJDIR)
 
-LIB_SO := $(PRODUCT_OBJDIR)/lib$(C_LIB).so
-LIB_AR := $(LIB_SO:%.so=%.a)
+BINELF := $(PRODUCT_OBJDIR)/$(C_BIN)
 
 H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
 C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
-APIHDR := $(I_HDRS:%=$(OBJDIR)/$(PRODIR)/%)
 
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
 
-# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
+# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_BIN>)
 DEPDIR := $(foreach dep,$(DEPEND),$(firstword $(subst :, ,$(dep))))
 DEPTGT := $(foreach dep,$(DEPEND),$(lastword $(subst :, ,$(dep))))
 DEP_SO := $(foreach dep,$(DEPEND),$(patsubst %,$(OBJDIR)/%.so,$(subst :,/lib,$(dep))))
@@ -29,7 +27,7 @@ DEPINC := $(DEPDIR:%=-I$(OBJDIR)/%)
 DEP_LD := $(DEPDIR:%=-L$(OBJDIR)/%)
 DEP_LD += $(DEPTGT:%=-l:lib%.a)
 
-CFLAGS += -Wall -g -O3 -fPIC
+CFLAGS += -Wall -g -O3
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += $(DEP_LD)
@@ -37,36 +35,21 @@ LFLAGS += $(DEP_LD)
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_OBJS)))
 
-# Build dep .so first
-$(LIB_SO): $(DEP_SO) $(C_OBJS) | $(APIHDR)
+# Build dep .a first but omit those files while linking
+$(BINELF): $(DEP_AR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(CC) $(LFLAGS) -shared -o $@ $^
+	$(Q)$(CC) -o $@ $(filter %.o,$^) $(LFLAGS)
 
-# Build dep .a first
-$(LIB_AR): $(DEP_AR) $(C_OBJS) | $(APIHDR)
-	@echo "Creating $@"
-	$(Q)$(AR) -c -r -s -o $@ $^
-
-# Create symllink to each include header in target obj directory
-$(sort $(dir $(APIHDR))):
-	$(Q)mkdir -p $@
-define HDR_SYMLINK_TGT
-$(1): $(subst $(OBJDIR)/,,$(1)) | $(dir $(1))
-	$(Q)ln -sf $(abspath $$<) $(abspath $$@)
-endef
-$(foreach hdr,$(APIHDR),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
-
-all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
+all.$(PRODUCT): $(BINELF)
 
 clean.$(PRODUCT):
 	@echo "Removing $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 # Preserve target specific values of [applicable] variables
-$(LIB_SO) $(LIB_AR):: CC := $(CC)
-$(LIB_SO) $(LIB_AR):: AR := $(AR)
-$(LIB_SO) $(LIB_AR):: CFLAGS := $(CFLAGS)
-$(LIB_SO) $(LIB_AR):: LFLAGS := $(LFLAGS)
+$(BINELF):: CC := $(CC)
+$(BINELF):: CFLAGS := $(CFLAGS)
+$(BINELF):: LFLAGS := $(LFLAGS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 
-endif  # define C_LIB
+endif  # define C_BIN

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -5,10 +5,7 @@ PRODUCT := $(C_BIN)
 # For top Makefile
 PRODUCTS += $(PRODUCT)
 
-OBJDIR := objs.$(TARGET_ARCH)
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
-# For top Makefile
-OBJDIRS += $(OBJDIR)
 
 BINELF := $(PRODUCT_OBJDIR)/$(C_BIN)
 

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -1,0 +1,70 @@
+ifdef C_LIB
+
+# This file defines rules for targets: [all|clean].$(PRODUCT)
+PRODUCT := $(C_LIB)
+# For top Makefile
+PRODUCTS += $(PRODUCT)
+
+OBJDIR := objs.$(TARGET_ARCH)
+PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+# For top Makefile
+OBJDIRS += $(OBJDIR)
+
+LIB_SO := $(PRODUCT_OBJDIR)/$(C_LIB).so
+LIB_AR := $(LIB_SO:%.so=%.a)
+
+H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
+C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
+APIHDR := $(I_HDRS:%=$(OBJDIR)/$(PRODIR)/%)
+
+# For top Makefile
+OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
+
+# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
+DEPDIR := $(foreach dep,$(DEPEND),$(firstword $(subst :, ,$(dep))))
+DEPTGT := $(foreach dep,$(DEPEND),$(lastword $(subst :, ,$(dep))))
+DEP_SO := $(foreach dep,$(DEPEND),$(patsubst %,$(OBJDIR)/%.so,$(subst :,/,$(dep))))
+DEP_AR := $(DEP_SO:%.so=%.a)
+DEPINC := $(DEPDIR:%=-I$(OBJDIR)/%)
+DEP_LD := $(DEPDIR:%=-L$(OBJDIR)/%)
+DEP_LD += $(DEPTGT:%=-l%)
+
+CFLAGS += -Wall -g -O3 -fPIC
+CFLAGS += $(H_INCS)
+CFLAGS += $(DEPINC)
+LFLAGS += $(DEP_LD)
+
+# Add targets for each .o file
+$(eval $(call add_c_obj_tgts,$(C_OBJS)))
+
+$(LIB_SO): $(C_OBJS) $(DEP_SO)
+	@echo "Creating $@"
+	$(Q)$(CC) $(LFLAGS) -shared -o $@ $^
+
+$(LIB_AR): $(C_OBJS) $(DEP_AR)
+	@echo "Creating $@"
+	$(Q)$(AR) -c -r -s -o $@ $^
+
+# Create symllink to each include header in target obj directory
+$(sort $(dir $(APIHDR))):
+	@mkdir -p $@
+define HDR_SYMLINK_TGT
+$(1): $(subst $(OBJDIR)/,,$(1)) | $(dir $(1))
+	@ln -sf $$< $$@
+endef
+$(foreach hdr,$(APIHDR),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
+
+all.$(PRODUCT): $(LIB_SO) $(LIB_AR) $(APIHDR)
+
+clean.$(PRODUCT):
+	@echo "Removing $(PRODUCT_OBJDIR)"
+	$(Q)rm -rf $(PRODUCT_OBJDIR)
+
+all.$(PRODUCT) clean.$(PRODUCT):: CC := $(CC)
+all.$(PRODUCT) clean.$(PRODUCT):: AR := $(AR)
+all.$(PRODUCT) clean.$(PRODUCT):: CFLAGS := $(CFLAGS)
+all.$(PRODUCT) clean.$(PRODUCT):: LFLAGS := $(LFLAGS)
+all.$(PRODUCT) clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+
+endif  # define C_LIB
+

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -5,10 +5,7 @@ PRODUCT := $(C_LIB)
 # For top Makefile
 PRODUCTS += $(PRODUCT)
 
-OBJDIR := objs.$(TARGET_ARCH)
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
-# For top Makefile
-OBJDIRS += $(OBJDIR)
 
 LIB_SO := $(PRODUCT_OBJDIR)/lib$(C_LIB).so
 LIB_AR := $(LIB_SO:%.so=%.a)

--- a/build/Makefile.firmware
+++ b/build/Makefile.firmware
@@ -1,0 +1,4 @@
+CROSS_COMPILE_PREFIX := /usr/bin/arm-none-eabi-
+CC := $(CROSS_COMPILE_PREFIX)gcc
+AR := $(CROSS_COMPILE_PREFIX)ar
+OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -1,17 +1,14 @@
 ifdef STM32_ELF
 
-# Override to use arm-none-eabi-gcc
-include $(Makefile.arm)
+# Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location
+include $(Makefile.firmware)
+OBJDIR := $(OBJDIR_PREFIX)firmware
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 PRODUCT := $(STM32_ELF)
 # For top Makefile
 PRODUCTS += $(PRODUCT)
-
-OBJDIR := objs.arm
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
-# For top Makefile
-OBJDIRS += $(OBJDIR)
 
 ELF := $(PRODUCT_OBJDIR)/$(STM32_ELF).elf
 BIN := $(ELF:%.elf=%.bin)

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -10,6 +10,8 @@ PRODUCTS += $(PRODUCT)
 
 OBJDIR := objs.arm
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+# For top Makefile
+OBJDIRS += $(OBJDIR)
 
 ELF := $(PRODUCT_OBJDIR)/$(STM32_ELF).elf
 BIN := $(ELF:%.elf=%.bin)
@@ -29,17 +31,8 @@ CFLAGS += $(H_INCS)
 CFLAGS += -DSTM32F401xE
 LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
 
-define C_OBJ_TGT
-$(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
-	@if [ "$(VERBOSE)" ]; then \
-		echo "Building $$< => $$@"; \
-	fi;
-	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@
-	@mv -f $$*.Td $$*.d && touch $$@
-
-include $(wildcard $(patsubst %,%.d,$(basename $(1))))
-endef
-$(foreach OBJFILE,$(C_OBJS),$(eval $(call C_OBJ_TGT,$(OBJFILE))))
+# Add targets for each .o file
+$(eval $(call add_c_obj_tgts,$(C_OBJS)))
 
 define S_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -61,10 +61,11 @@ clean.$(PRODUCT):
 	@echo "Removing $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
-all.$(PRODUCT) clean.$(PRODUCT):: CC := $(CC)
-all.$(PRODUCT) clean.$(PRODUCT):: OBJCOPY := $(OBJCOPY)
-all.$(PRODUCT) clean.$(PRODUCT):: CFLAGS := $(CFLAGS)
-all.$(PRODUCT) clean.$(PRODUCT):: LFLAGS := $(LFLAGS)
-all.$(PRODUCT) clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+# Preserve target specific values of [applicable] variables
+$(ELF):: CC := $(CC)
+$(ELF):: CFLAGS := $(CFLAGS)
+$(ELF):: LFLAGS := $(LFLAGS)
+$(HEX) $(BIN):: OBJCOPY := $(OBJCOPY)
+clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 
 endif  # define STM32_ELF

--- a/build/Makefile.x86_64
+++ b/build/Makefile.x86_64
@@ -1,0 +1,3 @@
+CC := gcc
+AR := ar
+OBJCOPY := objcopy

--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := common
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/Makefile.defs
+++ b/cmds/Makefile.defs
@@ -1,0 +1,1 @@
+../Makefile.defs

--- a/cmds/common/Makefile
+++ b/cmds/common/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := hello_world
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/common/Makefile.defs
+++ b/cmds/common/Makefile.defs
@@ -1,0 +1,1 @@
+../../Makefile.defs

--- a/cmds/common/hello_world/Makefile
+++ b/cmds/common/hello_world/Makefile
@@ -1,0 +1,12 @@
+C_BIN := hello_world
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS := src/hello_world.c
+
+# "deps"
+DEPEND := libs/common/hello:hello
+
+include Makefile.defs
+$(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/cmds/common/hello_world/Makefile.defs
+++ b/cmds/common/hello_world/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/cmds/common/hello_world/src/hello_world.c
+++ b/cmds/common/hello_world/src/hello_world.c
@@ -1,0 +1,7 @@
+#include "inc/hello.h"
+
+int main(void)
+{
+    print_msg("Hello World!");
+    return 0;
+}

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := common
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/Makefile.defs
+++ b/libs/Makefile.defs
@@ -1,0 +1,1 @@
+../Makefile.defs

--- a/libs/common/Makefile
+++ b/libs/common/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := hello
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/common/Makefile.defs
+++ b/libs/common/Makefile.defs
@@ -1,0 +1,1 @@
+../../Makefile.defs

--- a/libs/common/hello/Makefile
+++ b/libs/common/hello/Makefile
@@ -1,0 +1,18 @@
+C_LIB := hello
+
+# "includes"
+H_DIRS := inc
+# "srcs"
+C_SRCS := src/hello.c
+# "hdrs"
+I_HDRS := inc/hello.h
+
+# "deps"
+# no external dependency (optional. stating it as demo)
+# DEPEND := libs/common/newlib:new
+# DEPEND += libs/common/extras:ext
+# DEPEND += libs/common/blabla:bla
+DEPEND :=
+
+include Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/common/hello/Makefile.defs
+++ b/libs/common/hello/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/libs/common/hello/inc/hello.h
+++ b/libs/common/hello/inc/hello.h
@@ -1,0 +1,14 @@
+#ifndef HELLO_H
+#define HELLO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void print_msg(const char *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HELLO_H

--- a/libs/common/hello/src/hello.c
+++ b/libs/common/hello/src/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "hello.h"
+
+void print_msg(const char *msg)
+{
+    printf("%s\n", msg);
+}


### PR DESCRIPTION
Mainly needed support to build a C library (to compile `libopencm3`, `FreeRTOS` as library etc.). For testing added C binary rule which makes it easier to test (especially dependencies).

Also added support to cross-compile for `aarch64`. It also builds `aarch64` natively; that way, `aarch64` hosts can be used to be build natively.