### PR TITLE
build: added support to build arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ ifeq ($(TOPDIR),)
 $(error "Not a git repository.")
 endif
 TARGET_ARCH := $(shell uname -m)
-SUPPORTED_ARCHS := aarch64 x86_64
+SUPPORTED_ARCHS := $(TARGET_ARCH) arm
+ifeq ($(TARGET_ARCH),x86_64)
+SUPPORTED_ARCHS += aarch64
+endif
 OBJDIR_PREFIX := objs.
 
 #
@@ -42,7 +45,16 @@ $(OBJ_SUBDIRS):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 clean: $(patsubst %,clean.%,$(PRODUCTS))
+	$(Q)rm -rf $(OBJDIR_PREFIX)$(ARCH)
+
+#
+# Wrapper useful "clean" targets
+#
+cleanall:
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
+
+clobber: cleanall
+	$(Q)rm -f cscope.* tags
 
 .DEFAULT_GOAL := all
 
@@ -53,8 +65,14 @@ include $(Makefile.buildenv)
 
 help:
 	@echo "Build Targets"
-	@echo "        all: build all firmware objects (default)"
-	@echo "      clean: remove all previously built firmware objects"
+	@echo "        all: build all $(ARCH) products (default)"
+	@echo "      clean: remove all previously built $(ARCH) products"
+	@echo "   cleanall: remove all products for all targets architectues"
+	@echo "    clobber: cleanall + remove cscope/ctags"
 	@echo "       help: show this message"
 	@echo
 	@$(MAKE) --no-print-directory help.buildenv
+	@echo
+	@echo "Commmand-line overrides"
+	@echo "       ARCH: build for a target architecture (Supported: $(SUPPORTED_ARCHS) | Default: $(TARGET_ARCH))"
+	@echo "    VERBOSE: build verbose level (Supported: 1 2 | Default: quiet)"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -14,6 +14,7 @@
 #
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
 Makefile.aarch64 := $(_TOPDIR_)/build/Makefile.aarch64
+Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
 Makefile.cbin := $(_TOPDIR_)/build/Makefile.cbin
 Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
@@ -126,9 +127,13 @@ include $(Makefile.$(1))
 endif
 endef
 
+#
+# Macro specifying rules to build an individual C object target and wrapper macro
+# that accepts multiple C object targets and calls the worker macro
+#
 define C_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
-	@if [ "$(VERBOSE)" ]; then \
+	@if [ "$(VERBOSE)" = "1" ]; then \
 		echo "Building $$< => $$@"; \
 	fi;
 	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@
@@ -136,7 +141,24 @@ $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
 
 include $(wildcard $(patsubst %,%.d,$(basename $(1))))
 endef
-
 define add_c_obj_tgts
 $$(foreach OBJFILE,$(1),$$(eval $$(call C_OBJ_TGT,$$(OBJFILE))))
+endef
+
+#
+# Evaluate depency targets, CFLAGS and LFLAGS for deps as specified by $(DEPEND).
+# This is common eval between Makefile.{cbin,clib}.
+#  [in] - $(DEPEND), $(OBJDIR)
+# [out] - Dependency targets: $(DEP_SO) $(DEP_AR)
+#         Dependency CFLAGS: $(DEPINC)
+#         Dependency LFLAGS: $(DEP_LD)
+#
+define eval_clib_deps
+DEPDIR := $$(foreach dep,$$(DEPEND),$$(firstword $$(subst :, ,$$(dep))))
+DEPTGT := $$(foreach dep,$$(DEPEND),$$(lastword $$(subst :, ,$$(dep))))
+DEP_SO := $$(foreach dep,$$(DEPEND),$$(patsubst %,$$(OBJDIR)/%.so,$$(subst :,/lib,$$(dep))))
+DEP_AR := $$(DEP_SO:%.so=%.a)
+DEPINC := $$(DEPDIR:%=-I$$(OBJDIR)/%)
+DEP_LD := $$(DEPDIR:%=-L$$(OBJDIR)/%)
+DEP_LD += $$(DEPTGT:%=-l:lib%.a)
 endef

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -7,13 +7,18 @@ RUN apt-get update && \
         binutils-arm-none-eabi \
         cmake \
         docker.io \
-	gcc-aarch64-linux-gnu \
+	gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
         libusb-1.0 \
         make \
+	qemu-user \
         openocd \
         sudo \
         wget
+
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+        apt-get install -y gcc-aarch64-linux-gnu; \
+    fi
 
 RUN wget https://github.com/stlink-org/stlink/archive/refs/tags/v1.6.1.tar.gz && \
     tar xfz v1.6.1.tar.gz && cd stlink-1.6.1 && \

--- a/build/Makefile.arm
+++ b/build/Makefile.arm
@@ -1,0 +1,8 @@
+ifneq ($(TARGET_ARCH),arm)
+CROSS_COMPILE_PREFIX := /usr/bin/arm-linux-gnueabihf-
+else
+CROSS_COMPILE_PREFIX :=
+endif
+CC := $(CROSS_COMPILE_PREFIX)gcc
+AR := $(CROSS_COMPILE_PREFIX)ar
+OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -15,18 +15,13 @@ C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
 
-# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_BIN>)
-DEPDIR := $(foreach dep,$(DEPEND),$(firstword $(subst :, ,$(dep))))
-DEPTGT := $(foreach dep,$(DEPEND),$(lastword $(subst :, ,$(dep))))
-DEP_SO := $(foreach dep,$(DEPEND),$(patsubst %,$(OBJDIR)/%.so,$(subst :,/lib,$(dep))))
-DEP_AR := $(DEP_SO:%.so=%.a)
-DEPINC := $(DEPDIR:%=-I$(OBJDIR)/%)
-DEP_LD := $(DEPDIR:%=-L$(OBJDIR)/%)
-DEP_LD += $(DEPTGT:%=-l:lib%.a)
+# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
+$(eval $(call eval_clib_deps))
 
 CFLAGS += -Wall -g -O3
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
+LFLAGS += -static
 LFLAGS += $(DEP_LD)
 
 # Add targets for each .o file

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -18,17 +18,12 @@ APIHDR := $(I_HDRS:%=$(OBJDIR)/$(PRODIR)/%)
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
 
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
-DEPDIR := $(foreach dep,$(DEPEND),$(firstword $(subst :, ,$(dep))))
-DEPTGT := $(foreach dep,$(DEPEND),$(lastword $(subst :, ,$(dep))))
-DEP_SO := $(foreach dep,$(DEPEND),$(patsubst %,$(OBJDIR)/%.so,$(subst :,/lib,$(dep))))
-DEP_AR := $(DEP_SO:%.so=%.a)
-DEPINC := $(DEPDIR:%=-I$(OBJDIR)/%)
-DEP_LD := $(DEPDIR:%=-L$(OBJDIR)/%)
-DEP_LD += $(DEPTGT:%=-l:lib%.a)
+$(eval $(call eval_clib_deps))
 
 CFLAGS += -Wall -g -O3 -fPIC
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
+LFLAGS += -shared
 LFLAGS += $(DEP_LD)
 
 # Add targets for each .o file
@@ -37,7 +32,7 @@ $(eval $(call add_c_obj_tgts,$(C_OBJS)))
 # Build dep .so first
 $(LIB_SO): $(DEP_SO) $(C_OBJS) | $(APIHDR)
 	@echo "Creating $@"
-	$(Q)$(CC) $(LFLAGS) -shared -o $@ $^
+	$(Q)$(CC) $(LFLAGS) -o $@ $^
 
 # Build dep .a first
 $(LIB_AR): $(DEP_AR) $(C_OBJS) | $(APIHDR)

--- a/libs/common/hello/Makefile
+++ b/libs/common/hello/Makefile
@@ -9,10 +9,9 @@ I_HDRS := inc/hello.h
 
 # "deps"
 # no external dependency (optional. stating it as demo)
-# DEPEND := libs/common/newlib:new
-# DEPEND += libs/common/extras:ext
-# DEPEND += libs/common/blabla:bla
 DEPEND :=
+
+# TODO: support "include_prefix" and "strip_include_prefix"
 
 include Makefile.defs
 $(eval $(call inc_rule,clib,$(C_LIB)))


### PR DESCRIPTION
Cleaned up native build for aarch64
Refactoed to reuse some common code
Fixed C_BIN to link statically

Tested on `x86_64` host with
```
# Build for all 3 supported ARCHs
$ make env
$ make cleanall

$ make all.hello_world
Creating objs.x86_64/libs/common/hello/libhello.a
Creating objs.x86_64/cmds/common/hello_world/hello_world

$ make all.hello_world ARCH=aarch64
Creating objs.aarch64/libs/common/hello/libhello.a
Creating objs.aarch64/cmds/common/hello_world/hello_world

$ make all.hello_world ARCH=arm
Creating objs.arm/libs/common/hello/libhello.a
Creating objs.arm/cmds/common/hello_world/hello_world

# Test the resultant binaries using qemu-user
$ objs.x86_64/cmds/common/hello_world/hello_world
Hello World!

$ qemu-aarch64 objs.aarch64/cmds/common/hello_world/hello_world
Hello World!

$ qemu-arm objs.arm/cmds/common/hello_world/hello_world
Hello World!
```