### PR TITLE
Link with freertos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ TOPDIR := $(shell git rev-parse --show-toplevel 2>/dev/null)
 ifeq ($(TOPDIR),)
 $(error "Not a git repository.")
 endif
+SHELL := $(shell which bash)
 TARGET_ARCH := $(shell uname -m)
 SUPPORTED_ARCHS := $(TARGET_ARCH) arm
 ifeq ($(TARGET_ARCH),x86_64)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ $(error Error: Unsupported ARCH: "$(ARCH)" (Supported: $(SUPPORTED_ARCHS) | Defa
 endif
 
 #
-# Variables populated by makesfiles at each level that includes Makefile.<rule>
+# Variables populated by makefiles at each level that includes Makefile.<rule>
 #
 PRODUCTS :=
 OBJ_SUBDIRS :=
@@ -51,6 +51,7 @@ clean: $(patsubst %,clean.%,$(PRODUCTS))
 # Wrapper useful "clean" targets
 #
 cleanall:
+	@echo "Removing $(OBJDIR_PREFIX)*"
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 clobber: cleanall

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -134,7 +134,7 @@ endef
 #
 define C_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
-	@if [ "$(VERBOSE)" = "1" ]; then \
+	@if [ $(VERBOSE) -ge 1 ]; then \
 		echo "Building $$< => $$@"; \
 	fi;
 	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,14 +13,11 @@
 # always resolve.
 #
 _TOPDIR_ := $(shell git rev-parse --show-toplevel)
-Makefile.aarch64 := $(_TOPDIR_)/build/Makefile.aarch64
-Makefile.arm := $(_TOPDIR_)/build/Makefile.arm
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
 Makefile.cbin := $(_TOPDIR_)/build/Makefile.cbin
 Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
-Makefile.firmware := $(_TOPDIR_)/build/Makefile.firmware
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
-Makefile.x86_64 := $(_TOPDIR_)/build/Makefile.x86_64
+Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
 
 #
 # Common constants
@@ -31,6 +28,7 @@ STM32_CFLAGS := -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb
 #
 # Helper command line variable for build debugging
 #
+VERBOSE ?= 0
 ifeq ($(VERBOSE),2)
 Q :=
 else
@@ -74,6 +72,10 @@ ALL_RULES := STM32_ELF C_LIB C_BIN
 PROD_PATT := $(ALL_RULES:%=/^%/)
 PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 
+#
+# Import toolchain include macro
+#
+include $(Makefile.toolchain)
 
 #
 # Wrapper macro to "subdirs" macro. Depending upon which directory "$(MAKE)"
@@ -85,7 +87,7 @@ PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 #
 #
 define inc_subdir
-include $(Makefile.$(ARCH))
+$$(eval $$(call inc_toolchain,$$(ARCH)))
 
 ifeq ($(TOPDIR),)
 
@@ -134,7 +136,7 @@ endef
 #
 define C_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
-	@if [ $(VERBOSE) -ge 1 ]; then \
+	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $$< => $$@"; \
 	fi;
 	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -148,7 +148,7 @@ endef
 
 #
 # Evaluate depency targets, CFLAGS and LFLAGS for deps as specified by $(DEPEND).
-# This is common eval between Makefile.{cbin,clib}.
+# This is common eval between Makefile.{cbin,clib,stm32}.
 #  [in] - $(DEPEND), $(OBJDIR)
 # [out] - Dependency targets: $(DEP_SO) $(DEP_AR)
 #         Dependency CFLAGS: $(DEPINC)

--- a/build/Makefile.aarch64
+++ b/build/Makefile.aarch64
@@ -1,8 +1,0 @@
-ifneq ($(TARGET_ARCH),aarch64)
-CROSS_COMPILE_PREFIX := /usr/bin/aarch64-linux-gnu-
-else
-CROSS_COMPILE_PREFIX :=
-endif
-CC := $(CROSS_COMPILE_PREFIX)gcc
-AR := $(CROSS_COMPILE_PREFIX)ar
-OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.arm
+++ b/build/Makefile.arm
@@ -1,8 +1,0 @@
-ifneq ($(TARGET_ARCH),arm)
-CROSS_COMPILE_PREFIX := /usr/bin/arm-linux-gnueabihf-
-else
-CROSS_COMPILE_PREFIX :=
-endif
-CC := $(CROSS_COMPILE_PREFIX)gcc
-AR := $(CROSS_COMPILE_PREFIX)ar
-OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -21,6 +21,7 @@ OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
 $(eval $(call eval_clib_deps))
 
 CFLAGS += -Wall -g -O3 -fPIC
+CFLAGS += -I$(PRODUCT_OBJDIR)
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += -shared
@@ -50,14 +51,14 @@ endef
 $(foreach hdr,$(I_HDRS),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
 
 # Build dep .so first
-$(LIB_SO): $(DEP_SO) $(C_OBJS) | $(APIHDR)
+$(LIB_SO): $(DEP_SO) $(APIHDR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(CC) $(LFLAGS) -o $@ $^
+	$(Q)$(CC) $(LFLAGS) -o $@ $(filter-out %.h,$^)
 
 # Build dep .a first
-$(LIB_AR): $(DEP_AR) $(C_OBJS) | $(APIHDR)
+$(LIB_AR): $(DEP_AR) $(APIHDR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(AR) -c -r -s -o $@ $^
+	$(Q)$(AR) -c -r -s -o $@ $(filter-out %.h,$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 

--- a/build/Makefile.firmware
+++ b/build/Makefile.firmware
@@ -1,4 +1,0 @@
-CROSS_COMPILE_PREFIX := /usr/bin/arm-none-eabi-
-CC := $(CROSS_COMPILE_PREFIX)gcc
-AR := $(CROSS_COMPILE_PREFIX)ar
-OBJCOPY := $(CROSS_COMPILE_PREFIX)objcopy

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -23,10 +23,15 @@ LD_SRC := $(LD_SRC:%=$(PRODIR)/%)
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS)))
 
+# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
+$(eval $(call eval_clib_deps))
+
 CFLAGS += $(STM32_CFLAGS)
 CFLAGS += $(H_INCS)
 CFLAGS += -DSTM32F401xE
+CFLAGS += $(DEPINC)
 LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
+LFLAGS += $(DEP_LD)
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_OBJS)))
@@ -40,9 +45,10 @@ $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))
 endef
 $(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))
 
-$(ELF): $(LD_SRC) $(C_OBJS) $(S_OBJS)
+# Build dep .a first but omit those files while linking
+$(ELF): $(LD_SRC) $(DEP_AR) $(C_OBJS) $(S_OBJS)
 	@echo "Creating $@"
-	$(Q)$(CC) $(LFLAGS) -T $^ -o $@
+	$(Q)$(CC) -T $(filter %.ld,$^) $(filter %.o,$^) $(LFLAGS) -o $@
 
 $(BIN): $(ELF)
 	@echo "Creating $@"

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -1,8 +1,7 @@
 ifdef STM32_ELF
 
 # Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location
-include $(Makefile.firmware)
-OBJDIR := $(OBJDIR_PREFIX)firmware
+$(eval $(call inc_toolchain,firmware))
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 PRODUCT := $(STM32_ELF)

--- a/build/Makefile.toolchain
+++ b/build/Makefile.toolchain
@@ -1,0 +1,23 @@
+define inc_toolchain
+TGT := $(1)
+
+ifeq ($$(TGT),firmware)
+CROSS_COMPILE_PREFIX := /usr/bin/arm-none-eabi-
+else ifeq ($$(TARGET_ARCH),$$(TGT))
+CROSS_COMPILE_PREFIX :=
+else ifeq ($$(TGT),aarch64)
+CROSS_COMPILE_PREFIX := /usr/bin/aarch64-linux-gnu-
+else ifeq ($$(TGT),arm)
+CROSS_COMPILE_PREFIX := /usr/bin/arm-linux-gnueabihf-
+else ifeq ($$(TGT),x86_64)
+CROSS_COMPILE_PREFIX :=
+else
+$$(error ERROR: Bogus target value '$$(TGT)')
+endif
+
+CC := $$(CROSS_COMPILE_PREFIX)gcc
+AR := $$(CROSS_COMPILE_PREFIX)ar
+OBJCOPY := $$(CROSS_COMPILE_PREFIX)objcopy
+
+OBJDIR := $$(OBJDIR_PREFIX)$$(TGT)
+endef

--- a/build/Makefile.x86_64
+++ b/build/Makefile.x86_64
@@ -1,3 +1,0 @@
-CC := gcc
-AR := ar
-OBJCOPY := objcopy

--- a/firmware/libs/FreeRTOS/Makefile
+++ b/firmware/libs/FreeRTOS/Makefile
@@ -4,13 +4,12 @@ C_LIB := freertos
 
 # "includes"
 H_DIRS := $(shell find $(THIS_DIR) -name "*.h" -exec dirname {} \+ 2>/dev/null | uniq | sed "s|$(THIS_DIR)||")
-H_DIRS += config
 
 # "srcs"
 C_SRCS := croutine.c list.c queue.c event_groups.c timers.c tasks.c stream_buffer.c portable/GCC/ARM_CM4F/port.c portable/MemMang/heap_1.c
 
 # "hdrs"
-I_HDRS := $(shell find $(THIS_DIR)/include -name "*.h" 2>/dev/null | uniq | sed "s|$(THIS_DIR)/||")
+I_HDRS := $(shell find $(THIS_DIR)/{include,config} -name "*.h" 2>/dev/null | uniq | sed "s|$(THIS_DIR)/||")
 
 # "deps"
 # no external dependency (optional. stating it as demo)
@@ -19,7 +18,7 @@ DEPEND :=
 # strip_include_prefix
 STRIP_INC_PREFIX := include
 # include_prefix
-INC_PREFIX := freertos
+INC_PREFIX :=
 
 CFLAGS += $(STM32_CFLAGS)
 CFLAGS += -mthumb-interwork -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -std=gnu90 -ffunction-sections -fdata-sections

--- a/firmware/libs/FreeRTOS/Makefile
+++ b/firmware/libs/FreeRTOS/Makefile
@@ -26,6 +26,5 @@ CFLAGS += -mthumb-interwork -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -std=gnu90 -ffu
 include Makefile.defs
 
 # Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location
-include $(Makefile.firmware)
-OBJDIR := $(OBJDIR_PREFIX)firmware
+$(eval $(call inc_toolchain,firmware))
 $(eval $(call inc_rule,clib,$(C_LIB)))

--- a/firmware/libs/FreeRTOS/include/FreeRTOS.h
+++ b/firmware/libs/FreeRTOS/include/FreeRTOS.h
@@ -54,7 +54,7 @@
 /* *INDENT-ON* */
 
 /* Application specific configuration options. */
-#include "FreeRTOSConfig.h"
+#include "config/FreeRTOSConfig.h"
 
 /* Basic FreeRTOS definitions. */
 #include "projdefs.h"

--- a/libs/common/hello/Makefile
+++ b/libs/common/hello/Makefile
@@ -1,7 +1,7 @@
 C_LIB := hello
 
 # "includes"
-H_DIRS := inc
+H_DIRS :=
 # "srcs"
 C_SRCS := src/hello.c
 # "hdrs"

--- a/libs/common/hello/src/hello.c
+++ b/libs/common/hello/src/hello.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "hello.h"
+#include "libhello/hello.h"
 
 void print_msg(const char *msg)
 {


### PR DESCRIPTION
Except for `FreeRTOSConfig.h`, `FreeRTOS` source can be built into an archive which then can link with a f/w ELF. The header file is venue for "application specific definitions". It's unclear whether that would change for different type of f/w builds but will tackle once integration and testing on real h/w is conducted.

Tested **build** with `Lidar_Delivery` nucleo f/w with following patch:
```
diff --git a/firmware/nucleo/Lidar_Delivery/Makefile b/firmware/nucleo/Lidar_Delivery/Makefile
index a2e643b..f154ed7 100644
--- a/firmware/nucleo/Lidar_Delivery/Makefile
+++ b/firmware/nucleo/Lidar_Delivery/Makefile
@@ -6,5 +6,13 @@ C_SRCS := $(shell find $(THIS_DIR) -name "*.c" -printf "%P\n" 2>/dev/null | sed
 S_SRCS := $(shell find $(THIS_DIR) -name "*.s" -printf "%P\n" 2>/dev/null | sed "s|^\./||")
 LD_SRC := LinkerScript.ld

+C_SRCS := $(subst src/stm32f4xx_it.c,,$(C_SRCS))
+
+DEPEND := firmware/libs/FreeRTOS:freertos
+
+# This is needed to include portable/GCC/ARM_CM4F/portmacro.h for nucleo board
+# instead of including portable/GCC/ARM_CM7/r0p1/portmacro.h
+CFLAGS += -Ifirmware/libs/FreeRTOS/portable/GCC/ARM_CM4F/
+
 include Makefile.defs
 $(eval $(call inc_rule,stm32,$(STM32_ELF)))
diff --git a/firmware/nucleo/Lidar_Delivery/src/main.c b/firmware/nucleo/Lidar_Delivery/src/main.c
index 813c52a..a407036 100644
--- a/firmware/nucleo/Lidar_Delivery/src/main.c
+++ b/firmware/nucleo/Lidar_Delivery/src/main.c
@@ -41,6 +41,10 @@
 #include "VL53L1X_api.h"
 #include "math.h"

+#include "FreeRTOS.h"
+#include "config/FreeRTOSConfig.h"
+#include "task.h"
+
 #define RadarCircleRadius                                              (110.0 / 2.0)
 #define Pi                                                                             3.1415
 #define VHV_TIMER                                                              200
@@ -128,8 +132,14 @@ void ResetAndInitializeAllSensors(void);
 void MX_GPIO_Init(void);
 void SystemClock_Config(void);

+static void vLEDFlashTask(void *pvParameters)
+{
+}
+
 /* -----Main program ----- */

+#define ledSTACK_SIZE  configMINIMAL_STACK_SIZE
+#define ledPRIORITY            ( tskIDLE_PRIORITY + 1UL )
 int main(void)
 {
        VL53L1X_ERROR error = 0;
@@ -146,6 +156,12 @@ int main(void)
        I2C_Init();             /* Initialize I2C interface      */
        //GPIO_Expander_Init();
        ResetAndInitializeAllSensors();
+#if 1
+       xTaskCreate(vLEDFlashTask, "LED1", ledSTACK_SIZE, (void *)NULL,
+                   ledPRIORITY, (TaskHandle_t *) NULL);
+
+       vTaskStartScheduler();
+#endif
        while (1)
        {
                error = 0;
```

That said, a few details regarding integration needs to be ironed out. Will revisit again.