### PR TITLE
build: added support to build C++ binary and library

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -152,7 +152,7 @@ GCC := $$(CC)
 # Ignore CXXFLAGS for .c files
 CXXFLAGS :=
 else
-$$(error ERROR: C_OBJ_TGT() => Invalid suffix '$$(SUFFIX)')
+$$(error ERROR: Invalid C/C++ suffix '$(1)' (Supported: .c $$(CC_EXTS)))
 endif
 
 OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(1))

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -24,6 +24,12 @@ Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
 #
 DEPFLAGS = -MT $@ -MMD -MP -MF $*.Td
 STM32_CFLAGS := -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb
+# Supported C++ source and header extensions. Excludes .c because
+# that's what distinguishes a C file from C++ file
+CC_EXTS := .cpp .cc
+CC_H_EXTS := .hpp .h .hh
+CC_EXTS_PATT := $(CC_EXTS:%=\%%))
+CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
 
 #
 # Helper command line variable for build debugging
@@ -60,6 +66,7 @@ C_BIN :=
 PRODUCT :=
 CFLAGS :=
 LFLAGS :=
+CXXFLAGS :=
 
 include $(1)/Makefile
 endef
@@ -131,21 +138,37 @@ endif
 endef
 
 #
-# Macro specifying rules to build an individual C object target and wrapper macro
-# that accepts multiple C object targets and calls the worker macro
+# Macro specifying rules to build an individual C/C++ object target and wrapper macro
+# that accepts multiple C/C++ source files and calls the worker macro
 #
 define C_OBJ_TGT
-$(1): $(subst $(OBJDIR)/,,$(1:%.o=%.c)) | $(dir $(1))
+
+SUFFIX := $$(suffix $(1))
+
+ifeq ($$(SUFFIX),$$(filter $$(SUFFIX),$$(CC_EXTS)))
+GCC := $$(CXX)
+else ifeq ($$(SUFFIX),.c)
+GCC := $$(CC)
+# Ignore CXXFLAGS for .c files
+CXXFLAGS :=
+else
+$$(error ERROR: C_OBJ_TGT() => Invalid suffix '$$(SUFFIX)')
+endif
+
+OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(1))
+
+$$(OBJFILE):: GCC := $$(GCC)
+$$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $$< => $$@"; \
 	fi;
-	$(Q)$$(CC) $$(CFLAGS) $$(DEPFLAGS) -c $$< -o $$@
+	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@
 
-include $(wildcard $(patsubst %,%.d,$(basename $(1))))
+include $$(wildcard $$(patsubst %,%.d,$$(basename $$(OBJFILE))))
 endef
 define add_c_obj_tgts
-$$(foreach OBJFILE,$(1),$$(eval $$(call C_OBJ_TGT,$$(OBJFILE))))
+$$(foreach SRCFILE,$(1),$$(eval $$(call C_OBJ_TGT,$$(SRCFILE))))
 endef
 
 #

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -7,6 +7,8 @@ RUN apt-get update && \
         binutils-arm-none-eabi \
         cmake \
         docker.io \
+	g++ \
+	g++-arm-linux-gnueabihf \
 	gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
         libusb-1.0 \
@@ -17,7 +19,7 @@ RUN apt-get update && \
         wget
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \
-        apt-get install -y gcc-aarch64-linux-gnu; \
+        apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu; \
     fi
 
 RUN wget https://github.com/stlink-org/stlink/archive/refs/tags/v1.6.1.tar.gz && \

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -10,7 +10,8 @@ PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 BINELF := $(PRODUCT_OBJDIR)/$(C_BIN)
 
 H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
-C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
+C_OBJS := $(patsubst %.c,$(OBJDIR)/$(PRODIR)/%.o,$(filter %.c,$(C_SRCS)))
+$(foreach cc_ext_patt,$(CC_EXTS_PATT),$(eval C_OBJS += $(patsubst $(cc_ext_patt),$(OBJDIR)/$(PRODIR)/%.o,$(filter $(cc_ext_patt),$(C_SRCS)))))
 
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
@@ -23,14 +24,15 @@ CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += -static
 LFLAGS += $(DEP_LD)
+CXXFLAGS += --std=c++17
 
 # Add targets for each .o file
-$(eval $(call add_c_obj_tgts,$(C_OBJS)))
+$(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 
 # Build dep .a first but omit those files while linking
 $(BINELF): $(DEP_AR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(CC) -o $@ $(filter %.o,$^) $(LFLAGS)
+	$(Q)$(CXX) -o $@ $(filter %.o,$^) $(LFLAGS)
 
 all.$(PRODUCT): $(BINELF)
 
@@ -40,8 +42,10 @@ clean.$(PRODUCT):
 
 # Preserve target specific values of [applicable] variables
 $(BINELF):: CC := $(CC)
+$(BINELF):: CXX := $(CXX)
 $(BINELF):: CFLAGS := $(CFLAGS)
 $(BINELF):: LFLAGS := $(LFLAGS)
+$(BINELF):: CXXFLAGS := $(CXXFLAGS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 
 endif  # define C_BIN

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -11,7 +11,8 @@ LIB_SO := $(PRODUCT_OBJDIR)/lib$(C_LIB).so
 LIB_AR := $(LIB_SO:%.so=%.a)
 
 H_INCS := $(H_DIRS:%=-I$(PRODIR)/%)
-C_OBJS := $(C_SRCS:%.c=$(OBJDIR)/$(PRODIR)/%.o)
+C_OBJS := $(patsubst %.c,$(OBJDIR)/$(PRODIR)/%.o,$(filter %.c,$(C_SRCS)))
+$(foreach cc_ext_patt,$(CC_EXTS_PATT),$(eval C_OBJS += $(patsubst $(cc_ext_patt),$(OBJDIR)/$(PRODIR)/%.o,$(filter $(cc_ext_patt),$(C_SRCS)))))
 APIHDR :=
 
 # For top Makefile
@@ -26,9 +27,10 @@ CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += -shared
 LFLAGS += $(DEP_LD)
+CXXFLAGS += --std=c++17
 
 # Add targets for each .o file
-$(eval $(call add_c_obj_tgts,$(C_OBJS)))
+$(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 
 # Create symllink to each include header in target obj directory
 # Determine if include_prefix should be stripped and/or added
@@ -53,12 +55,12 @@ $(foreach hdr,$(I_HDRS),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
 # Build dep .so first
 $(LIB_SO): $(DEP_SO) $(APIHDR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(CC) $(LFLAGS) -o $@ $(filter-out %.h,$^)
+	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
 $(LIB_AR): $(DEP_AR) $(APIHDR) $(C_OBJS)
 	@echo "Creating $@"
-	$(Q)$(AR) -c -r -s -o $@ $(filter-out %.h,$^)
+	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
@@ -68,9 +70,11 @@ clean.$(PRODUCT):
 
 # Preserve target specific values of [applicable] variables
 $(LIB_SO) $(LIB_AR):: CC := $(CC)
+$(LIB_SO) $(LIB_AR):: CXX := $(CXX)
 $(LIB_SO) $(LIB_AR):: AR := $(AR)
 $(LIB_SO) $(LIB_AR):: CFLAGS := $(CFLAGS)
 $(LIB_SO) $(LIB_AR):: LFLAGS := $(LFLAGS)
+$(LIB_SO) $(LIB_AR):: CXXFLAGS := $(CXXFLAGS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 
 endif  # define C_LIB

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -33,7 +33,7 @@ LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
 LFLAGS += $(DEP_LD)
 
 # Add targets for each .o file
-$(eval $(call add_c_obj_tgts,$(C_OBJS)))
+$(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 
 define S_OBJ_TGT
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))

--- a/build/Makefile.toolchain
+++ b/build/Makefile.toolchain
@@ -1,8 +1,10 @@
 define inc_toolchain
 TGT := $(1)
+GXX := g++
 
 ifeq ($$(TGT),firmware)
 CROSS_COMPILE_PREFIX := /usr/bin/arm-none-eabi-
+GXX := gcc
 else ifeq ($$(TARGET_ARCH),$$(TGT))
 CROSS_COMPILE_PREFIX :=
 else ifeq ($$(TGT),aarch64)
@@ -16,6 +18,7 @@ $$(error ERROR: Bogus target value '$$(TGT)')
 endif
 
 CC := $$(CROSS_COMPILE_PREFIX)gcc
+CXX := $$(CROSS_COMPILE_PREFIX)$$(GXX)
 AR := $$(CROSS_COMPILE_PREFIX)ar
 OBJCOPY := $$(CROSS_COMPILE_PREFIX)objcopy
 

--- a/cmds/common/Makefile
+++ b/cmds/common/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := hello_world
+SUBDIRS := hello_world hello_world_cpp
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/common/hello_world_cpp/Makefile
+++ b/cmds/common/hello_world_cpp/Makefile
@@ -1,0 +1,12 @@
+C_BIN := hello_world_cpp
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS := src/hello_world.cpp
+
+# "deps"
+DEPEND := libs/common/hello_cpp:hello_cpp
+
+include Makefile.defs
+$(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/cmds/common/hello_world_cpp/Makefile.defs
+++ b/cmds/common/hello_world_cpp/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/cmds/common/hello_world_cpp/src/hello_world.cpp
+++ b/cmds/common/hello_world_cpp/src/hello_world.cpp
@@ -1,0 +1,7 @@
+#include "libhello_cpp/hello.hpp"
+
+int main(void) {
+  common::Hello hello("Tejas");
+  hello.printMsg("Hello CPP World!");
+  return 0;
+}

--- a/libs/common/Makefile
+++ b/libs/common/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := hello
+SUBDIRS := hello hello_cpp
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/common/hello_cpp/Makefile
+++ b/libs/common/hello_cpp/Makefile
@@ -1,0 +1,20 @@
+C_LIB := hello_cpp
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS := src/hello.cpp
+# "hdrs"
+I_HDRS := inc/hello.hpp
+
+# "deps"
+# no external dependency (optional. stating it as demo)
+DEPEND :=
+
+# strip_include_prefix
+STRIP_INC_PREFIX := inc
+# include_prefix
+INC_PREFIX := libhello_cpp
+
+include Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/common/hello_cpp/Makefile.defs
+++ b/libs/common/hello_cpp/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/libs/common/hello_cpp/inc/hello.hpp
+++ b/libs/common/hello_cpp/inc/hello.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace common {
+
+class Hello {
+  public:
+   explicit Hello(const std::string& user = "Guest");
+   void printMsg(const std::string& msg);
+  private:
+   std::string user_;
+};
+
+}  // namespace common

--- a/libs/common/hello_cpp/src/hello.cpp
+++ b/libs/common/hello_cpp/src/hello.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include <string>
+
+#include "libhello_cpp/hello.hpp"
+
+namespace common {
+
+Hello::Hello(const std::string& user) : user_(user) {}
+
+void Hello::printMsg(const std::string& msg) {
+  std::cout << msg << " " << user_ << std::endl;
+}
+
+}  // namespace common


### PR DESCRIPTION
Basic rule to build C++ source. Reused `C_BIN` and `C_LIB` rules to build C++: build C and C++ files with `gcc` and `g++` respectively; link both with `g++`. This is necessary to allow all `gcc` features to be available to C files.

Did basic testing with an example C++ library and a binary. Haven't tested linking C and C++ sources but should work. Also tested on `x86_64` host the cross-compiled `arm` and `aarch64` binaries (using `qemu-[arm|aarch64]`.

`g++` takes significantly longer to statically link `.cpp` objects than `.c` objects. Not sure whether that's because of choice of `CFLAGS` and `CXXFLAGS`. Will revisit.