### PR TITLE
Protobuf CC support for x86_64, aarch64 and arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
 #
 # Common targets (after defining rules for targets at each level)
 #
-$(OBJ_SUBDIRS):
+$(sort $(OBJ_SUBDIRS)):
 	@mkdir -p $@
 
 #

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -16,6 +16,7 @@ _TOPDIR_ := $(shell git rev-parse --show-toplevel)
 Makefile.buildenv := $(_TOPDIR_)/build/Makefile.buildenv
 Makefile.cbin := $(_TOPDIR_)/build/Makefile.cbin
 Makefile.clib := $(_TOPDIR_)/build/Makefile.clib
+Makefile.protobuf := $(_TOPDIR_)/build/Makefile.protobuf
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
 
@@ -28,8 +29,19 @@ STM32_CFLAGS := -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb
 # that's what distinguishes a C file from C++ file
 CC_EXTS := .cpp .cc
 CC_H_EXTS := .hpp .h .hh
-CC_EXTS_PATT := $(CC_EXTS:%=\%%))
+CC_EXTS_PATT := $(CC_EXTS:%=\%%)
 CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
+# PROTOBUF ARCH dependent CFLAGS and LFLAGS
+PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
+PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
+
+#
+# All supported rules and grep pattern to help locate
+# all the targets in a directory
+#
+ALL_RULES := STM32_ELF C_LIB C_BIN PROTO_LIB
+PROD_PATT := $(ALL_RULES:%=/^%/)
+PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 
 #
 # Helper command line variable for build debugging
@@ -54,10 +66,7 @@ OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
 #
 # Variables representing supported product build rules.
 #
-STM32_ELF :=
-C_LIB :=
-C_BIN :=
-
+$$(foreach RULE,$(ALL_RULES),$$(eval $$(RULE) := ))
 
 #
 # Rules for targets "[all|clean].$(PRODUCT)" would need their own
@@ -71,13 +80,6 @@ CXXFLAGS :=
 include $(1)/Makefile
 endef
 
-
-#
-# Enlist all supported rules to help locate all the targets in a directory
-#
-ALL_RULES := STM32_ELF C_LIB C_BIN
-PROD_PATT := $(ALL_RULES:%=/^%/)
-PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 
 #
 # Import toolchain include macro
@@ -158,6 +160,8 @@ endif
 OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(1))
 
 $$(OBJFILE):: GCC := $$(GCC)
+$$(OBJFILE):: CFLAGS := $$(CFLAGS)
+$$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $$< => $$@"; \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -157,7 +157,9 @@ else
 $$(error ERROR: Invalid C/C++ suffix '$(1)' (Supported: .c $$(CC_EXTS)))
 endif
 
-OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(1))
+# Remove $(OBJDIR) prefix from "SRCFILE" (aka $(1)) [in case if it's a generated one]
+# before adding it as a prefix to "OBJFILE"
+OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(subst $(OBJDIR)/,,$(1)))
 
 $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -4,18 +4,23 @@ FROM ubuntu:bionic
 
 RUN apt-get update && \
     apt-get install -y \
+        autoconf \
+	automake \
         binutils-arm-none-eabi \
         cmake \
+	curl \
         docker.io \
 	g++ \
 	g++-arm-linux-gnueabihf \
 	gcc-arm-linux-gnueabihf \
         gcc-arm-none-eabi \
+	libtool \
         libusb-1.0 \
         make \
-	qemu-user \
         openocd \
+	qemu-user \
         sudo \
+	unzip \
         wget
 
 RUN if [ "$(uname -m)" = "x86_64" ]; then \
@@ -26,6 +31,21 @@ RUN wget https://github.com/stlink-org/stlink/archive/refs/tags/v1.6.1.tar.gz &&
     tar xfz v1.6.1.tar.gz && cd stlink-1.6.1 && \
     make install CMAKEFLAGS="-DCMAKE_INSTALL_PREFIX:PATH=/usr" && \
     rm -rf v1.6.1.tar.gz stlink-1.6.1
+
+ENV VER=3.15.8
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${VER}/protobuf-cpp-${VER}.tar.gz && \
+    tar xfz protobuf-cpp-${VER}.tar.gz && cd protobuf-${VER} && \
+    ./autogen.sh && ./configure --prefix=/usr/local/$(uname -m) && \
+    make install && \
+    make distclean && \
+    ./configure --host=$(uname -m) CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ --prefix=/usr/local/arm && \
+    make install && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        make distclean && \
+        ./configure --host=$(uname -m) CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ --prefix=/usr/local/aarch64 && \
+        make install; \
+    fi && \
+    cd .. && rm -rf protobuf-cpp-${VER}.tar.gz* protobuf-${VER}
 
 # Add "this" user to buildenv image
 ARG USER

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -7,36 +7,32 @@ PRODUCTS += $(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 
-CC_PROTO_TGT_DIR := $(PRODUCT_OBJDIR)
-
-LIB_SO := $(CC_PROTO_TGT_DIR)/lib$(PROTO_LIB).so
+LIB_SO := $(PRODUCT_OBJDIR)/lib$(PROTO_LIB).so
 LIB_AR := $(LIB_SO:%.so=%.a)
 
-PB_CC_OBJS := $(PB_SRCS:%.proto=$(CC_PROTO_TGT_DIR)/%.pb.o)
+PB_CC_OBJS := $(PB_SRCS:%.proto=$(PRODUCT_OBJDIR)/%.pb.o)
+# For top Makefile
+OBJ_SUBDIRS += $(sort $(dir $(PB_CC_OBJS)))
 
 CFLAGS += -fPIC $(PROTOBUF_CFLAGS)
 LFLAGS += -shared $(PROTOBUF_LFLAGS)
 CXXFLAGS += --std=c++17
 
-$(CC_PROTO_TGT_DIR):
-	$(Q)mkdir -p $@
+# Add targets to generate .cc file from .proto files
+PB_CC_SRCS :=
+define pb_cc_src_tgt
 
-define pb_cc_obj_tgt
+PB_CC_FILE := $(PRODUCT_OBJDIR)/$(1:%.proto=%.pb.cc)
 
-PB_CC_FILE := $(CC_PROTO_TGT_DIR)/$(1:%.proto=%.pb.cc)
-PB_O_FILE := $$(PB_CC_FILE:%.cc=%.o)
+$$(PB_CC_FILE): $(PRODIR)/$(1) | $$(dir $$(PB_CC_FILE))
+	$(Q)$(PROTOC) -I $(PRODIR) $$^ --cpp_out=$(PRODUCT_OBJDIR)
 
-$$(PB_CC_FILE): $(PRODIR)/$(1) | $(CC_PROTO_TGT_DIR)
-	$(Q)$(PROTOC) -I $(PRODIR) $$^ --cpp_out=$(CC_PROTO_TGT_DIR)
-
-$$(PB_O_FILE):: CXX := $$(CXX)
-$$(PB_O_FILE):: CFLAGS := $$(CFLAGS)
-$$(PB_O_FILE):: CXXFLAGS := $$(CXXFLAGS)
-$$(PB_O_FILE):: CC_PROTO_TGT_DIR := $$(CC_PROTO_TGT_DIR)
-$$(PB_O_FILE): $$(PB_CC_FILE)
-	$(Q)$(CXX) $(CFLAGS) $(CXXFLAGS) -I $(CC_PROTO_TGT_DIR) -c $$^ -o $$@
+PB_CC_SRCS += $$(PB_CC_FILE)
 endef
-$(foreach pb_src,$(PB_SRCS),$(eval $(call pb_cc_obj_tgt,$(pb_src))))
+$(foreach pb_src,$(PB_SRCS),$(eval $(call pb_cc_src_tgt,$(pb_src))))
+
+# Add targets for each .o file
+$(eval $(call add_c_obj_tgts,$(PB_CC_SRCS)))
 
 # Build dep .so first
 $(LIB_SO): $(PB_CC_OBJS)

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -1,0 +1,65 @@
+ifdef PROTO_LIB
+
+# This file defines rules for targets: [all|clean].$(PRODUCT)
+PRODUCT := $(PROTO_LIB)
+# For top Makefile
+PRODUCTS += $(PRODUCT)
+
+PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+
+CC_PROTO_TGT_DIR := $(PRODUCT_OBJDIR)
+
+LIB_SO := $(CC_PROTO_TGT_DIR)/lib$(PROTO_LIB).so
+LIB_AR := $(LIB_SO:%.so=%.a)
+
+PB_CC_OBJS := $(PB_SRCS:%.proto=$(CC_PROTO_TGT_DIR)/%.pb.o)
+
+CFLAGS += -fPIC $(PROTOBUF_CFLAGS)
+LFLAGS += -shared $(PROTOBUF_LFLAGS)
+CXXFLAGS += --std=c++17
+
+$(CC_PROTO_TGT_DIR):
+	$(Q)mkdir -p $@
+
+define pb_cc_obj_tgt
+
+PB_CC_FILE := $(CC_PROTO_TGT_DIR)/$(1:%.proto=%.pb.cc)
+PB_O_FILE := $$(PB_CC_FILE:%.cc=%.o)
+
+$$(PB_CC_FILE): $(PRODIR)/$(1) | $(CC_PROTO_TGT_DIR)
+	$(Q)$(PROTOC) -I $(PRODIR) $$^ --cpp_out=$(CC_PROTO_TGT_DIR)
+
+$$(PB_O_FILE):: CXX := $$(CXX)
+$$(PB_O_FILE):: CFLAGS := $$(CFLAGS)
+$$(PB_O_FILE):: CXXFLAGS := $$(CXXFLAGS)
+$$(PB_O_FILE):: CC_PROTO_TGT_DIR := $$(CC_PROTO_TGT_DIR)
+$$(PB_O_FILE): $$(PB_CC_FILE)
+	$(Q)$(CXX) $(CFLAGS) $(CXXFLAGS) -I $(CC_PROTO_TGT_DIR) -c $$^ -o $$@
+endef
+$(foreach pb_src,$(PB_SRCS),$(eval $(call pb_cc_obj_tgt,$(pb_src))))
+
+# Build dep .so first
+$(LIB_SO): $(PB_CC_OBJS)
+	@echo "Creating $@"
+	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
+
+# Build dep .a first
+$(LIB_AR): $(PB_CC_OBJS)
+	@echo "Creating $@"
+	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
+
+all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
+
+clean.$(PRODUCT):
+	@echo "Removing $(PRODUCT_OBJDIR)"
+	$(Q)rm -rf $(PRODUCT_OBJDIR)
+
+# Preserve target specific values of [applicable] variables
+$(LIB_SO) $(LIB_AR):: CXX := $(CXX)
+$(LIB_SO) $(LIB_AR):: AR := $(AR)
+$(LIB_SO) $(LIB_AR):: CFLAGS := $(CFLAGS)
+$(LIB_SO) $(LIB_AR):: LFLAGS := $(LFLAGS)
+$(LIB_SO) $(LIB_AR):: CXXFLAGS := $(CXXFLAGS)
+clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+
+endif

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -14,8 +14,13 @@ PB_CC_OBJS := $(PB_SRCS:%.proto=$(PRODUCT_OBJDIR)/%.pb.o)
 # For top Makefile
 OBJ_SUBDIRS += $(sort $(dir $(PB_CC_OBJS)))
 
+# Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
+$(eval $(call eval_clib_deps))
+
 CFLAGS += -fPIC $(PROTOBUF_CFLAGS)
+CFLAGS += $(DEPINC)
 LFLAGS += -shared $(PROTOBUF_LFLAGS)
+LFLAGS += $(DEP_LD)
 CXXFLAGS += --std=c++17
 
 # Add targets to generate .cc file from .proto files
@@ -35,12 +40,12 @@ $(foreach pb_src,$(PB_SRCS),$(eval $(call pb_cc_src_tgt,$(pb_src))))
 $(eval $(call add_c_obj_tgts,$(PB_CC_SRCS)))
 
 # Build dep .so first
-$(LIB_SO): $(PB_CC_OBJS)
+$(LIB_SO): $(DEP_SO) $(PB_CC_OBJS)
 	@echo "Creating $@"
 	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
-$(LIB_AR): $(PB_CC_OBJS)
+$(LIB_AR): $(DEP_AR) $(PB_CC_OBJS)
 	@echo "Creating $@"
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 

--- a/build/Makefile.toolchain
+++ b/build/Makefile.toolchain
@@ -22,5 +22,7 @@ CXX := $$(CROSS_COMPILE_PREFIX)$$(GXX)
 AR := $$(CROSS_COMPILE_PREFIX)ar
 OBJCOPY := $$(CROSS_COMPILE_PREFIX)objcopy
 
+PROTOC := /usr/local/$$(TARGET_ARCH)/bin/protoc
+
 OBJDIR := $$(OBJDIR_PREFIX)$$(TGT)
 endef

--- a/cmds/common/Makefile
+++ b/cmds/common/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := hello_world hello_world_cpp
+SUBDIRS := hello_world hello_world_cpp pb_example
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/common/pb_example/Makefile
+++ b/cmds/common/pb_example/Makefile
@@ -1,0 +1,30 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+C_BIN := add_person
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS := src/add_person.cc
+
+# "deps"
+DEPEND := cmds/common/pb_example/proto:address_book
+
+CFLAGS += $(PROTOBUF_CFLAGS)
+LFLAGS += $(PROTOBUF_LFLAGS)
+
+include Makefile.defs
+$(eval $(call inc_rule,cbin,$(C_BIN)))
+
+# add another C_BIN
+C_BIN := list_people
+H_DIRS :=
+C_SRCS := src/list_people.cc
+DEPEND := cmds/common/pb_example/proto:address_book
+CFLAGS += $(PROTOBUF_CFLAGS)
+LFLAGS += $(PROTOBUF_LFLAGS)
+$(eval $(call inc_rule,cbin,$(C_BIN)))
+
+# add proto_lib
+SUBDIRS := proto
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/common/pb_example/proto/Makefile
+++ b/cmds/common/pb_example/proto/Makefile
@@ -1,0 +1,6 @@
+PROTO_LIB := address_book
+
+PB_SRCS := addressbook.proto
+
+include Makefile.defs
+$(eval $(call inc_rule,protobuf,$(PROTO_LIB)))

--- a/cmds/common/pb_example/proto/Makefile
+++ b/cmds/common/pb_example/proto/Makefile
@@ -2,5 +2,7 @@ PROTO_LIB := address_book
 
 PB_SRCS := addressbook.proto
 
+DEPEND :=
+
 include Makefile.defs
 $(eval $(call inc_rule,protobuf,$(PROTO_LIB)))

--- a/cmds/common/pb_example/proto/addressbook.proto
+++ b/cmds/common/pb_example/proto/addressbook.proto
@@ -1,0 +1,52 @@
+// See README.txt for information and build instructions.
+//
+// Note: START and END tags are used in comments to define sections used in
+// tutorials.  They are not part of the syntax for Protocol Buffers.
+//
+// To get an in-depth walkthrough of this file and the related examples, see:
+// https://developers.google.com/protocol-buffers/docs/tutorials
+
+// [START declaration]
+syntax = "proto3";
+package tutorial;
+
+import "google/protobuf/timestamp.proto";
+// [END declaration]
+
+// [START java_declaration]
+option java_multiple_files = true;
+option java_package = "com.example.tutorial.protos";
+option java_outer_classname = "AddressBookProtos";
+// [END java_declaration]
+
+// [START csharp_declaration]
+option csharp_namespace = "Google.Protobuf.Examples.AddressBook";
+// [END csharp_declaration]
+
+// [START messages]
+message Person {
+  string name = 1;
+  int32 id = 2;  // Unique ID number for this person.
+  string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    string number = 1;
+    PhoneType type = 2;
+  }
+
+  repeated PhoneNumber phones = 4;
+
+  google.protobuf.Timestamp last_updated = 5;
+}
+
+// Our address book file is just one of these.
+message AddressBook {
+  repeated Person people = 1;
+}
+// [END messages]

--- a/cmds/common/pb_example/src/add_person.cc
+++ b/cmds/common/pb_example/src/add_person.cc
@@ -1,0 +1,102 @@
+// See README.txt for information and build instructions.
+
+#include <ctime>
+#include <fstream>
+#include <google/protobuf/util/time_util.h>
+#include <iostream>
+#include <string>
+
+#include "addressbook.pb.h"
+
+using namespace std;
+
+using google::protobuf::util::TimeUtil;
+
+// This function fills in a Person message based on user input.
+void PromptForAddress(tutorial::Person* person) {
+  cout << "Enter person ID number: ";
+  int id;
+  cin >> id;
+  person->set_id(id);
+  cin.ignore(256, '\n');
+
+  cout << "Enter name: ";
+  getline(cin, *person->mutable_name());
+
+  cout << "Enter email address (blank for none): ";
+  string email;
+  getline(cin, email);
+  if (!email.empty()) {
+    person->set_email(email);
+  }
+
+  while (true) {
+    cout << "Enter a phone number (or leave blank to finish): ";
+    string number;
+    getline(cin, number);
+    if (number.empty()) {
+      break;
+    }
+
+    tutorial::Person::PhoneNumber* phone_number = person->add_phones();
+    phone_number->set_number(number);
+
+    cout << "Is this a mobile, home, or work phone? ";
+    string type;
+    getline(cin, type);
+    if (type == "mobile") {
+      phone_number->set_type(tutorial::Person::MOBILE);
+    } else if (type == "home") {
+      phone_number->set_type(tutorial::Person::HOME);
+    } else if (type == "work") {
+      phone_number->set_type(tutorial::Person::WORK);
+    } else {
+      cout << "Unknown phone type.  Using default." << endl;
+    }
+  }
+  *person->mutable_last_updated() = TimeUtil::SecondsToTimestamp(time(NULL));
+}
+
+// Main function:  Reads the entire address book from a file,
+//   adds one person based on user input, then writes it back out to the same
+//   file.
+int main(int argc, char* argv[]) {
+  // Verify that the version of the library that we linked against is
+  // compatible with the version of the headers we compiled against.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  if (argc != 2) {
+    cerr << "Usage:  " << argv[0] << " ADDRESS_BOOK_FILE" << endl;
+    return -1;
+  }
+
+  tutorial::AddressBook address_book;
+
+  {
+    // Read the existing address book.
+    fstream input(argv[1], ios::in | ios::binary);
+    if (!input) {
+      cout << argv[1] << ": File not found.  Creating a new file." << endl;
+    } else if (!address_book.ParseFromIstream(&input)) {
+      cerr << "Failed to parse address book." << endl;
+      return -1;
+    }
+  }
+
+  // Add an address.
+  PromptForAddress(address_book.add_people());
+
+  {
+    // Write the new address book back to disk.
+    fstream output(argv[1], ios::out | ios::trunc | ios::binary);
+    if (!address_book.SerializeToOstream(&output)) {
+      cerr << "Failed to write address book." << endl;
+      return -1;
+    }
+  }
+
+  // Optional:  Delete all global objects allocated by libprotobuf.
+  google::protobuf::ShutdownProtobufLibrary();
+
+  return 0;
+}

--- a/cmds/common/pb_example/src/address_book.cpp
+++ b/cmds/common/pb_example/src/address_book.cpp
@@ -1,0 +1,102 @@
+// See README.txt for information and build instructions.
+
+#include <ctime>
+#include <fstream>
+#include <google/protobuf/util/time_util.h>
+#include <iostream>
+#include <string>
+
+#include "address_book.pb.h"
+
+using namespace std;
+
+using google::protobuf::util::TimeUtil;
+
+// This function fills in a Person message based on user input.
+void PromptForAddress(tutorial::Person* person) {
+  cout << "Enter person ID number: ";
+  int id;
+  cin >> id;
+  person->set_id(id);
+  cin.ignore(256, '\n');
+
+  cout << "Enter name: ";
+  getline(cin, *person->mutable_name());
+
+  cout << "Enter email address (blank for none): ";
+  string email;
+  getline(cin, email);
+  if (!email.empty()) {
+    person->set_email(email);
+  }
+
+  while (true) {
+    cout << "Enter a phone number (or leave blank to finish): ";
+    string number;
+    getline(cin, number);
+    if (number.empty()) {
+      break;
+    }
+
+    tutorial::Person::PhoneNumber* phone_number = person->add_phones();
+    phone_number->set_number(number);
+
+    cout << "Is this a mobile, home, or work phone? ";
+    string type;
+    getline(cin, type);
+    if (type == "mobile") {
+      phone_number->set_type(tutorial::Person::MOBILE);
+    } else if (type == "home") {
+      phone_number->set_type(tutorial::Person::HOME);
+    } else if (type == "work") {
+      phone_number->set_type(tutorial::Person::WORK);
+    } else {
+      cout << "Unknown phone type.  Using default." << endl;
+    }
+  }
+  *person->mutable_last_updated() = TimeUtil::SecondsToTimestamp(time(NULL));
+}
+
+// Main function:  Reads the entire address book from a file,
+//   adds one person based on user input, then writes it back out to the same
+//   file.
+int main(int argc, char* argv[]) {
+  // Verify that the version of the library that we linked against is
+  // compatible with the version of the headers we compiled against.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  if (argc != 2) {
+    cerr << "Usage:  " << argv[0] << " ADDRESS_BOOK_FILE" << endl;
+    return -1;
+  }
+
+  tutorial::AddressBook address_book;
+
+  {
+    // Read the existing address book.
+    fstream input(argv[1], ios::in | ios::binary);
+    if (!input) {
+      cout << argv[1] << ": File not found.  Creating a new file." << endl;
+    } else if (!address_book.ParseFromIstream(&input)) {
+      cerr << "Failed to parse address book." << endl;
+      return -1;
+    }
+  }
+
+  // Add an address.
+  PromptForAddress(address_book.add_people());
+
+  {
+    // Write the new address book back to disk.
+    fstream output(argv[1], ios::out | ios::trunc | ios::binary);
+    if (!address_book.SerializeToOstream(&output)) {
+      cerr << "Failed to write address book." << endl;
+      return -1;
+    }
+  }
+
+  // Optional:  Delete all global objects allocated by libprotobuf.
+  google::protobuf::ShutdownProtobufLibrary();
+
+  return 0;
+}

--- a/cmds/common/pb_example/src/list_people.cc
+++ b/cmds/common/pb_example/src/list_people.cc
@@ -1,0 +1,79 @@
+// See README.txt for information and build instructions.
+
+#include <fstream>
+#include <google/protobuf/util/time_util.h>
+#include <iostream>
+#include <string>
+
+#include "addressbook.pb.h"
+
+using namespace std;
+
+using google::protobuf::util::TimeUtil;
+
+// Iterates though all people in the AddressBook and prints info about them.
+void ListPeople(const tutorial::AddressBook& address_book) {
+  for (int i = 0; i < address_book.people_size(); i++) {
+    const tutorial::Person& person = address_book.people(i);
+
+    cout << "Person ID: " << person.id() << endl;
+    cout << "  Name: " << person.name() << endl;
+    if (person.email() != "") {
+      cout << "  E-mail address: " << person.email() << endl;
+    }
+
+    for (int j = 0; j < person.phones_size(); j++) {
+      const tutorial::Person::PhoneNumber& phone_number = person.phones(j);
+
+      switch (phone_number.type()) {
+        case tutorial::Person::MOBILE:
+          cout << "  Mobile phone #: ";
+          break;
+        case tutorial::Person::HOME:
+          cout << "  Home phone #: ";
+          break;
+        case tutorial::Person::WORK:
+          cout << "  Work phone #: ";
+          break;
+        default:
+          cout << "  Unknown phone #: ";
+          break;
+      }
+      cout << phone_number.number() << endl;
+    }
+    if (person.has_last_updated()) {
+      cout << "  Updated: " << TimeUtil::ToString(person.last_updated()) << endl;
+    }
+  }
+}
+
+// Main function:  Reads the entire address book from a file and prints all
+//   the information inside.
+int main(int argc, char* argv[]) {
+  // Verify that the version of the library that we linked against is
+  // compatible with the version of the headers we compiled against.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  if (argc != 2) {
+    cerr << "Usage:  " << argv[0] << " ADDRESS_BOOK_FILE" << endl;
+    return -1;
+  }
+
+  tutorial::AddressBook address_book;
+
+  {
+    // Read the existing address book.
+    fstream input(argv[1], ios::in | ios::binary);
+    if (!address_book.ParseFromIstream(&input)) {
+      cerr << "Failed to parse address book." << endl;
+      return -1;
+    }
+  }
+
+  ListPeople(address_book);
+
+  // Optional:  Delete all global objects allocated by libprotobuf.
+  google::protobuf::ShutdownProtobufLibrary();
+
+  return 0;
+}


### PR DESCRIPTION
Same as `C_LIB` except an additional step of generating `.cc` from `.proto`. Needed to install `protobuf` 3 different ways in `buildenv`.

Used the same example online from official protobuf GitHub.

Tested with
```
# build 3 different ways on x86_64
$ make cleanall && make VERBOSE=2 && make ARCH=aarch64 VERBOSE=2 && make ARCH=arm VERBOSE=2

# test the generated bins (`/tmp/a.txt` was previously created using `objs.x86_64/cmds/common/pb_example/add_person`)
$ objs.x86_64/cmds/common/pb_example/list_people /tmp/a.txt && qemu-aarch64 objs.aarch64/cmds/common/pb_example/list_people /tmp/a.txt && objs.arm/cmds/common/pb_example/list_people /tmp/a.txt
```