### PR TITLE
Cflags change support

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -219,3 +219,27 @@ DEPINC := $$(DEPDIR:%=-I$$(OBJDIR)/%)
 DEP_LD := $$(DEPDIR:%=-L$$(OBJDIR)/%)
 DEP_LD += $$(DEPTGT:%=-l:lib%.a)
 endef
+
+define cflags_change_tgt
+# List of flags to detect change in
+DIFF_FLAGS := CFLAGS LFLAGS CXXFLAGS
+
+METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.mk
+METADATA_FILE_TMP := $$(METADATA_FILE:%=%.tmp)
+
+$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
+$(METADATA_FILE): clean_$(METADATA_FILE_TMP)
+	$$(foreach flag,$$(DIFF_FLAGS),$$(shell eval "echo $$(flag) := $$($$(flag)) >> $$(METADATA_FILE_TMP)"))
+	@if [ ! -f $$@ ] || ! diff $$@ $$(METADATA_FILE_TMP) >/dev/null; then \
+		[ -f $$@ ] && echo "$(1): Flags changed"; \
+		mv $$(METADATA_FILE_TMP) $$@; \
+	else \
+		rm $$(METADATA_FILE_TMP); \
+	fi
+
+clean_$(METADATA_FILE_TMP):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
+clean_$(METADATA_FILE_TMP):
+	@rm -f $$(METADATA_FILE_TMP)
+
+$(C_OBJS): $(METADATA_FILE)
+endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -224,11 +224,11 @@ define cflags_change_tgt
 # List of flags to detect change in
 DIFF_FLAGS := CFLAGS LFLAGS CXXFLAGS
 
-METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.mk
+METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.$(1).mk
 METADATA_FILE_TMP := $$(METADATA_FILE:%=%.tmp)
 
-$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
-$(METADATA_FILE): clean_$(METADATA_FILE_TMP)
+$$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
+$$(METADATA_FILE): clean_$$(METADATA_FILE_TMP) | $(OBJ_SUBDIRS)
 	$$(foreach flag,$$(DIFF_FLAGS),$$(shell eval "echo $$(flag) := $$($$(flag)) >> $$(METADATA_FILE_TMP)"))
 	@if [ ! -f $$@ ] || ! diff $$@ $$(METADATA_FILE_TMP) >/dev/null; then \
 		[ -f $$@ ] && echo "$(1): Flags changed"; \
@@ -237,9 +237,9 @@ $(METADATA_FILE): clean_$(METADATA_FILE_TMP)
 		rm $$(METADATA_FILE_TMP); \
 	fi
 
-clean_$(METADATA_FILE_TMP):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
-clean_$(METADATA_FILE_TMP):
+clean_$$(METADATA_FILE_TMP):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
+clean_$$(METADATA_FILE_TMP):
 	@rm -f $$(METADATA_FILE_TMP)
 
-$(C_OBJS): $(METADATA_FILE)
+$(C_OBJS): $$(METADATA_FILE)
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -228,7 +228,7 @@ METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.$(1).mk
 METADATA_FILE_TMP := $$(METADATA_FILE:%=%.tmp)
 
 $$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
-$$(METADATA_FILE): clean_$$(METADATA_FILE_TMP) | $(OBJ_SUBDIRS)
+$$(METADATA_FILE): clean_$$(METADATA_FILE_TMP) | $(PRODUCT_OBJDIR)
 	$$(foreach flag,$$(DIFF_FLAGS),$$(shell eval "echo $$(flag) := $$($$(flag)) >> $$(METADATA_FILE_TMP)"))
 	@if [ ! -f $$@ ] || ! diff $$@ $$(METADATA_FILE_TMP) >/dev/null; then \
 		[ -f $$@ ] && echo "$(1): Flags changed"; \

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -14,7 +14,7 @@ C_OBJS := $(patsubst %.c,$(OBJDIR)/$(PRODIR)/%.o,$(filter %.c,$(C_SRCS)))
 $(foreach cc_ext_patt,$(CC_EXTS_PATT),$(eval C_OBJS += $(patsubst $(cc_ext_patt),$(OBJDIR)/$(PRODIR)/%.o,$(filter $(cc_ext_patt),$(C_SRCS)))))
 
 # For top Makefile
-OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
+OBJ_SUBDIRS += $(sort $(dir $(C_OBJS))) $(PRODUCT_OBJDIR)
 
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -26,6 +26,9 @@ LFLAGS += -static
 LFLAGS += $(DEP_LD)
 CXXFLAGS += --std=c++17
 
+# Add targets to detect change in C flags
+$(eval $(call cflags_change_tgt,$(C_BIN)))
+
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -16,7 +16,7 @@ $(foreach cc_ext_patt,$(CC_EXTS_PATT),$(eval C_OBJS += $(patsubst $(cc_ext_patt)
 APIHDR :=
 
 # For top Makefile
-OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)))
+OBJ_SUBDIRS += $(sort $(dir $(C_OBJS))) $(PRODUCT_OBJDIR)
 
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -29,6 +29,9 @@ LFLAGS += -shared
 LFLAGS += $(DEP_LD)
 CXXFLAGS += --std=c++17
 
+# Add targets to detect change in C flags
+$(eval $(call cflags_change_tgt,$(C_LIB)))
+
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -20,7 +20,7 @@ S_OBJS := $(S_SRCS:%.s=$(OBJDIR)/$(PRODIR)/%.o)
 LD_SRC := $(LD_SRC:%=$(PRODIR)/%)
 
 # For top Makefile
-OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS)))
+OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS))) $(PRODUCT_OBJDIR)
 
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -32,6 +32,9 @@ CFLAGS += $(DEPINC)
 LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
 LFLAGS += $(DEP_LD)
 
+# Add targets to detect change in C flags
+$(eval $(call cflags_change_tgt,$(STM32_ELF)))
+
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 

--- a/cmds/common/pb_example/Makefile.defs
+++ b/cmds/common/pb_example/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/cmds/common/pb_example/proto/Makefile.defs
+++ b/cmds/common/pb_example/proto/Makefile.defs
@@ -1,0 +1,1 @@
+../../../../Makefile.defs


### PR DESCRIPTION
Pretty simple: save "C flags" in a file and compare previous ones with ones during current build. With this feature, now there's a log file that stores "C flags":
```
$ find . -name "metadata*mk" -exec bash -c "echo {}; cat {}; echo" \;
./objs.firmware/firmware/libs/FreeRTOS/metadata.freertos.mk
CFLAGS := -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb -mthumb-interwork -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -std=gnu90 -ffunction-sections -fdata-sections -Wall -g -O3 -fPIC -Iobjs.firmware/firmware/libs/FreeRTOS -Ifirmware/libs/FreeRTOS/config -Ifirmware/libs/FreeRTOS/include -Ifirmware/libs/FreeRTOS/portable/GCC/ARM_CM4F -Ifirmware/libs/FreeRTOS/portable/GCC/ARM_CM7/r0p1
LFLAGS := -shared
CXXFLAGS :=

./objs.firmware/firmware/nucleo/Lidar_Delivery/metadata.lidar_delivery.mk
CFLAGS := -mcpu=cortex-m4 -mlittle-endian -mthumb -Os -ggdb -Ifirmware/nucleo/Lidar_Delivery/CMSIS/core -Ifirmware/nucleo/Lidar_Delivery/CMSIS/device -Ifirmware/nucleo/Lidar_Delivery/HAL_Driver/Inc/Legacy -Ifirmware/nucleo/Lidar_Delivery/HAL_Driver/Inc -Ifirmware/nucleo/Lidar_Delivery/UltraLiteDriver -Ifirmware/nucleo/Lidar_Delivery/Utilities/STM32F4xx-Nucleo -Ifirmware/nucleo/Lidar_Delivery/inc -DSTM32F401xE
LFLAGS := -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,objs.firmware/firmware/nucleo/Lidar_Delivery/lidar_delivery.map
CXXFLAGS :=

./objs.x86_64/cmds/common/hello_world/metadata.hello_world.mk
CFLAGS := -Wall -g -O3 -Iobjs.x86_64/libs/common/hello
LFLAGS := -static -Lobjs.x86_64/libs/common/hello -l:libhello.a
CXXFLAGS :=

./objs.x86_64/cmds/common/hello_world_cpp/metadata.hello_world_cpp.mk
CFLAGS := -Wall -g -O3 -Iobjs.x86_64/libs/common/hello_cpp
LFLAGS := -static -Lobjs.x86_64/libs/common/hello_cpp -l:libhello_cpp.a
CXXFLAGS := --std=c++17

./objs.x86_64/cmds/common/pb_example/metadata.list_people.mk
CFLAGS := -pthread -I/usr/local/x86_64/include -Wall -g -O3 -Iobjs.x86_64/cmds/common/pb_example/proto
LFLAGS := -L/usr/local/x86_64/lib -lprotobuf -lpthread -static -Lobjs.x86_64/cmds/common/pb_example/proto -l:libaddress_book.a
CXXFLAGS := --std=c++17

./objs.x86_64/cmds/common/pb_example/metadata.add_person.mk
CFLAGS := -pthread -I/usr/local/x86_64/include -Wall -g -O3 -Iobjs.x86_64/cmds/common/pb_example/proto
LFLAGS := -L/usr/local/x86_64/lib -lprotobuf -lpthread -static -Lobjs.x86_64/cmds/common/pb_example/proto -l:libaddress_book.a
CXXFLAGS := --std=c++17

./objs.x86_64/libs/common/hello_cpp/metadata.hello_cpp.mk
CFLAGS := -Wall -g -O3 -fPIC -Iobjs.x86_64/libs/common/hello_cpp
LFLAGS := -shared
CXXFLAGS := --std=c++17

./objs.x86_64/libs/common/hello/metadata.hello.mk
CFLAGS := -Wall -g -O3 -fPIC -Iobjs.x86_64/libs/common/hello
LFLAGS := -shared
CXXFLAGS :=
```

Tested by changing `CFLAGS` on `libhello_cpp` and cmd `hello_world_cpp` and verified that they build only when flags are changed.

NOTE: Each build causes a temporary file to be written (to disk) to compare it with previous one. This may be optimized by slightly elaborate instrumentation. Will revisit.