### PR TITLE
build: refactor Dockerfile.buildenv for cleanliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,10 @@ help:
 	@$(MAKE) --no-print-directory help.buildenv
 	@echo
 	@echo "Commmand-line overrides"
-	@echo "        ARCH: build for a target architecture (Supported: $(SUPPORTED_ARCHS) | Default: $(TARGET_ARCH))"
-	@echo "     VERBOSE: build verbose level (Supported: 1 2 | Default: quiet)"
+	@echo "        ARCH: build for a target architecture"
+	@echo "              Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
+	@echo "     VERBOSE: build verbose level"
+	@echo "              Supported: 1 2 [Default: quiet]"
 	@echo
-	@echo "Other [than make based] supported build systems"
+	@echo "Other supported build systems (outside of default build system)"
 	@echo "         ROS: make help.ros"

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -26,54 +26,36 @@ RUN apt-get update && \
         qt5-default qtcreator \
         sudo \
 	unzip \
-        wget
-
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-        apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu; \
-    fi
-
-# st-link
-RUN wget https://github.com/stlink-org/stlink/archive/refs/tags/v1.6.1.tar.gz && \
-    tar xfz v1.6.1.tar.gz && cd stlink-1.6.1 && \
-    make install CMAKEFLAGS="-DCMAKE_INSTALL_PREFIX:PATH=/usr" && \
-    rm -rf v1.6.1.tar.gz stlink-1.6.1
-
-# protobuf
-ENV VER=3.15.8
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${VER}/protobuf-cpp-${VER}.tar.gz && \
-    tar xfz protobuf-cpp-${VER}.tar.gz && cd protobuf-${VER} && \
-    ./autogen.sh && ./configure --prefix=/usr/local/$(uname -m) && \
-    make -j $(nproc) install && \
-    make distclean && \
-    ./configure --host=$(uname -m) CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ --prefix=/usr/local/arm && \
-    make -j $(nproc) install && \
-    if [ "$(uname -m)" = "x86_64" ]; then \
-        make distclean && \
-        ./configure --host=$(uname -m) CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ --prefix=/usr/local/aarch64 && \
-        make -j $(nproc) install; \
-    fi && \
-    cd .. && rm -rf protobuf-cpp-${VER}.tar.gz* protobuf-${VER}
+        wget && \
+        if [ "$(uname -m)" = "x86_64" ]; then \
+            apt-get install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu; \
+        fi && \
+        apt-get clean all && \
+            rm -rf /var/lib/apt/lists/*
 
 # ROS1
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' && \
     apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 && \
     apt-get update && \
     apt-get install -y \
-    ros-noetic-ros-base \
-    python3-rosdep \
-    python3-rosinstall \
-    python3-rosinstall-generator \
-    python3-wstool \
-    build-essential
-
-RUN rosdep init && \
-    rosdep update || true
+        ros-noetic-ros-base && \
+    apt-get install -y \
+        python3-rosdep \
+        python3-rosinstall \
+        python3-rosinstall-generator \
+        python3-wstool \
+        build-essential && \
+    rosdep init && \
+        rosdep update || true; \
+    apt-get clean all && \
+        rm -rf /var/lib/apt/lists/*
 
 # ROS2
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null && \
     apt update && \
-    apt install -y ros-foxy-ros-base && \
+    apt install -y \
+        ros-foxy-ros-base && \
     apt install -y \
         libbullet-dev \
         python3-colcon-common-extensions \
@@ -102,9 +84,33 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o
     apt install --no-install-recommends -y \
         libcunit1-dev && \
     apt install -y \
-        ros-foxy-turtlesim
+        ros-foxy-turtlesim && \
+    rosdep init && \
+        rosdep update || true; \
+    apt-get clean all && \
+        rm -rf /var/lib/apt/lists/*
 
-RUN rosdep update || true
+# st-link
+RUN wget https://github.com/stlink-org/stlink/archive/refs/tags/v1.6.1.tar.gz && \
+    tar xfz v1.6.1.tar.gz && cd stlink-1.6.1 && \
+    make install CMAKEFLAGS="-DCMAKE_INSTALL_PREFIX:PATH=/usr" && \
+    rm -rf v1.6.1.tar.gz stlink-1.6.1
+
+# protobuf
+ENV VER=3.15.8
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${VER}/protobuf-cpp-${VER}.tar.gz && \
+    tar xfz protobuf-cpp-${VER}.tar.gz && cd protobuf-${VER} && \
+    ./autogen.sh && ./configure --prefix=/usr/local/$(uname -m) && \
+    make -j $(nproc) install && \
+    make distclean && \
+    ./configure --host=$(uname -m) CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ --prefix=/usr/local/arm && \
+    make -j $(nproc) install && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        make distclean && \
+        ./configure --host=$(uname -m) CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ --prefix=/usr/local/aarch64 && \
+        make -j $(nproc) install; \
+    fi && \
+    cd .. && rm -rf protobuf-cpp-${VER}.tar.gz* protobuf-${VER}
 
 # Add "this" user to buildenv image
 ARG USER

--- a/build/Makefile.buildenv
+++ b/build/Makefile.buildenv
@@ -37,7 +37,7 @@ define buildenv_container
 		$(DOCKER_CMD) run --name $(CONTAINER_NAME) --rm -d --privileged --net=host \
 			-u $(THIS_USER) \
 			-e USER=$(THIS_USER) -e DISPLAY=$$DISPLAY -e BUILDENV_SHELL=true \
-			-v /tmp/.X11-unix:/tmp/.X11-unix -v $(HOME)/.Xauthority:$(HOME)/.Xauthority -v "$(PWD):$(PWD)" -v $(DOCKER_SOCKET):$(DOCKER_SOCKET) -v /tmp:/tmp \
+			-v /tmp/.X11-unix:/tmp/.X11-unix -v $(HOME)/.Xauthority:$(HOME)/.Xauthority -v "$(PWD):$(PWD)" -v $(DOCKER_SOCKET):$(DOCKER_SOCKET) -v /dev:/dev -v /tmp:/tmp \
 			-w $(PWD) -it $(IMAGE_NAME); \
 	fi;
 endef


### PR DESCRIPTION
Build of `Dockerfile.buildenv` isn't consistent and often times it fails with:
```
At least one invalid signature was encountered.
```

Some refactoring was needed to consolidate build steps. And other minor fixes.

With fixes it seems to build okay and works as expected (including Qt `turtlesim`).