### PR TITLE
build: added support to build zephyr apps

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,7 +1,8 @@
 #
 # @file: Makefile that defines absolute paths and macro definitions for
 #        the build system for the repo. A symlink to this file must
-#        exist at each directory level of this repo.
+#        exist at each directory level of this repo to allow invoking
+#        and building at any sub-directory level.
 #
 
 
@@ -38,12 +39,9 @@ PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
 PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
 
 #
-# All supported rules and grep pattern to help locate
-# all the targets in a directory
+# All supported rules
 #
 ALL_RULES := STM32_ELF C_LIB C_BIN PROTO_LIB ZEPHYR_APP
-PROD_PATT := $(ALL_RULES:%=/^%/)
-PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 
 #
 # Enumerate name of attributes for each rule to undef them before inclusion
@@ -51,11 +49,12 @@ PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 #
 COMMON_ATTRS := PRODUCT
 COMMON_C_ATTRS := CFLAGS CXXFLAGS LFLAGS H_DIRS C_SRCS DEPEND
-STM32_ELF_ATTRS := S_SRCS LD_SRC $(COMMON_C_ATTRS) $(COMMON_ATTRS)
-C_LIB_ATTRS := I_HDRS STRIP_INC_PREFIX INC_PREFIX $(COMMON_C_ATTRS) $(COMMON_ATTRS)
-C_BIN_ATTRS := $(COMMON_C_ATTRS) $(COMMON_ATTRS)
+STM32_ELF_ATTRS := S_SRCS LD_SRC $(COMMON_C_ATTRS)
+C_LIB_ATTRS := I_HDRS STRIP_INC_PREFIX INC_PREFIX $(COMMON_C_ATTRS)
+C_BIN_ATTRS := $(COMMON_C_ATTRS)
 PROTO_LIB_ATTRS := PB_SRCS DEPEND
-ALL_ATTRS := $(sort $(foreach rule,$(ALL_RULES),$($(rule)_ATTRS)))
+ZEPHYR_APP_ATTRS := BOARD
+ALL_ATTRS := $(sort $(foreach rule,$(ALL_RULES),$($(rule)_ATTRS))) $(COMMON_ATTRS)
 
 
 #
@@ -105,30 +104,25 @@ endef
 #
 # Wrapper macro to "subdirs" macro. Depending upon which directory "$(MAKE)"
 # is invoked upon, this macro will either simply include subdirectories or
-# invoke appropriate targets from the $(TOPDIR).
-#
-# Initializes $(CC) for the target architecture.
-# May get overriden by a Makefile.<rule> (during $(call inc_rule,<rule>,<product>))
-#
+# recursively find all the "Makefile" from directories below and include them.
 #
 define inc_subdir
 ifeq ($(TOPDIR),)
+# This method won't honor if a subdir is present but isn't
+# enlisted in the makefile parent dir
+MKFILES += $(shell find $(1) -mindepth 2 -name Makefile)
 
-ifeq ($(MAKECMDGOALS),)
-TARGETS := all
-else
-TARGETS := $(MAKECMDGOALS)
+#
+# Accumulated makefiles need to be included only once;
+# use sort to enumuerate unique ones.
+#
+ifndef INC_MAKEFILE
+INC_MAKEFILE := 1
+$$(foreach makefile,$$(sort $$(MKFILES)),$$(eval include $$(makefile)))
 endif
 
-PROD_NAME := $(shell find $(1) -name Makefile -exec awk '$(PROD_PATT){print $$3}' {} \+)
-PROD_TGTS :=
-$$(foreach TGT,$$(TARGETS), $$(foreach PROD,$$(PROD_NAME),$$(eval PROD_TGTS += $$(TGT).$$(PROD))))
-
-$$(TARGETS):
-	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(PROD_TGTS)
 else
 $$(foreach SUBDIR,$(2:%=$(1)%),$$(eval $$(call subdirs,$$(SUBDIR))))
-
 endif
 endef
 
@@ -139,15 +133,28 @@ endef
 define inc_rule
 ifeq ($(TOPDIR),)
 
+#
+# inc_rule() may be called more than once in a Makefile and each
+# time, we accumulate goals to be built by updating TARGETS
+#
 ifeq ($(MAKECMDGOALS),)
-TARGETS := all.$(2)
+TARGETS += all.$(2)
 else
-TARGETS := $(MAKECMDGOALS:%=%.$(2))
-$(MAKECMDGOALS): $$(TARGETS)
+TARGETS += $(MAKECMDGOALS:%=%.$(2))
 endif
 
+#
+# o $$(TARGETS) needs to be defined only once.
+# o $$(TARGETS) is used in the definition since $$@
+#   expansion covers only the first target.
+#
+ifndef DEF_TARGETS
+DEF_TARGETS := 1
+
+$(MAKECMDGOALS): $$(TARGETS)
 $$(TARGETS):
-	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$@
+	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
+endif
 
 else
 include $(Makefile.$(1))
@@ -208,7 +215,7 @@ endef
 # Evaluate depency targets, CFLAGS and LFLAGS for deps as specified by $(DEPEND).
 # This is common eval between Makefile.{cbin,clib,stm32}.
 #  [in] - $(DEPEND), $(OBJDIR)
-# [out] - Dependency targets: $(DEP_SO) $(DEP_AR)
+# [out] - Dependency target names: $(DEP_SO) $(DEP_AR)
 #         Dependency CFLAGS: $(DEPINC)
 #         Dependency LFLAGS: $(DEP_LD)
 #
@@ -222,6 +229,14 @@ DEP_LD := $$(DEPDIR:%=-L$$(OBJDIR)/%)
 DEP_LD += $$(DEPTGT:%=-l:lib%.a)
 endef
 
+
+#
+# Macro to create target that's invoked if "cflags" of a product is changed from
+# previous build. It is also added as dependency on the "c-objects" of the product.
+#  [in] - "product name $(1)", $(PRODUCT_OBJDIR), $(CFLAGS), $(LFLAGS), $(CXXFLAGS)
+# [out] - Dependency target that detects changes in "cflags" and forces rebuild
+#         of "c-objects" of the product
+#
 define cflags_change_tgt
 # List of flags to detect change in
 DIFF_FLAGS := CFLAGS LFLAGS CXXFLAGS

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -20,6 +20,7 @@ Makefile.protobuf := $(_TOPDIR_)/build/Makefile.protobuf
 Makefile.ros := $(_TOPDIR_)/build/Makefile.ros
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
+Makefile.zephyr := $(_TOPDIR_)/build/Makefile.zephyr
 
 #
 # Common constants
@@ -40,7 +41,7 @@ PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
 # All supported rules and grep pattern to help locate
 # all the targets in a directory
 #
-ALL_RULES := STM32_ELF C_LIB C_BIN PROTO_LIB
+ALL_RULES := STM32_ELF C_LIB C_BIN PROTO_LIB ZEPHYR_APP
 PROD_PATT := $(ALL_RULES:%=/^%/)
 PROD_PATT := $(subst / /,/ || /,$(PROD_PATT))
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -109,7 +109,7 @@ endef
 define inc_subdir
 ifeq ($(TOPDIR),)
 # This method won't honor if a subdir is present but isn't
-# enlisted in the makefile parent dir
+# enlisted in the makefile of the parent dir
 MKFILES += $(shell find $(1) -mindepth 2 -name Makefile)
 
 #

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -112,6 +112,29 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${VER}/p
     fi && \
     cd .. && rm -rf protobuf-cpp-${VER}.tar.gz* protobuf-${VER}
 
+# zephyr
+RUN pip3 install wheel pip -U &&\
+    pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \
+    pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt && \
+    pip3 install west &&\
+    pip3 install sh &&\
+    pip3 install awscli PyGithub junitparser pylint \
+                 statistics numpy \
+                 imgtool \
+                 protobuf
+ENV VER=2.5.0
+ENV ZEPHYR_HOME=/zephyr
+RUN wget https://github.com/zephyrproject-rtos/zephyr/archive/refs/tags/zephyr-v${VER}.tar.gz && \
+    mkdir -p ${ZEPHYR_HOME} && tar xfz zephyr-v${VER}.tar.gz -C ${ZEPHYR_HOME} --strip-components 1 && \
+    rm -f zephyr-v${VER}.tar.gz && \
+    cd ${ZEPHYR_HOME} && west init && west update
+
+RUN apt-get update && \
+    apt-get install -y \
+        ninja-build && \
+    apt-get clean all && \
+        rm -rf /var/lib/apt/lists/*
+
 # Add "this" user to buildenv image
 ARG USER
 ARG GROUP
@@ -132,3 +155,8 @@ RUN if [ -n "$DOCKER_GID" ]; then \
         groupmod docker -g $DOCKER_GID; \
     fi && \
     usermod -aG docker $USER
+
+RUN chown -R $USER:$GROUP ${ZEPHYR_HOME}
+ENV ZEPHYR_BASE=${ZEPHYR_HOME}/zephyr
+ENV ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
+ENV CROSS_COMPILE=/usr/bin/arm-none-eabi-

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -160,7 +160,10 @@ RUN if [ -n "$DOCKER_GID" ]; then \
     fi && \
     usermod -aG docker $USER
 
+# Settings after $USER is added
 RUN chown -R $USER:$GROUP ${ZEPHYR_HOME}
+
+# Env variables for build to work as expected
 ENV ZEPHYR_BASE=${ZEPHYR_HOME}/zephyr
 ENV ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
 ENV CROSS_COMPILE=/usr/bin/arm-none-eabi-

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -113,7 +113,11 @@ RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${VER}/p
     cd .. && rm -rf protobuf-cpp-${VER}.tar.gz* protobuf-${VER}
 
 # zephyr
-RUN pip3 install wheel pip -U &&\
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; \
+        . $HOME/.cargo/env; \
+    fi && \
+    pip3 install wheel pip -U && \
     pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/master/scripts/requirements.txt && \
     pip3 install -r https://raw.githubusercontent.com/zephyrproject-rtos/mcuboot/master/scripts/requirements.txt && \
     pip3 install west &&\

--- a/build/Makefile.buildenv
+++ b/build/Makefile.buildenv
@@ -46,7 +46,7 @@ define buildenv_shell
 	if [ "$(BUILDENV_SHELL)" = "true" ]; then \
 		echo "Already inside buildenv-shell."; \
 	else \
-		$(DOCKER_CMD) exec -it $(CONTAINER_NAME) /bin/bash; \
+		$(DOCKER_CMD) exec -it $(CONTAINER_NAME) /bin/bash || true; \
 	fi;
 endef
 

--- a/build/Makefile.toolchain
+++ b/build/Makefile.toolchain
@@ -23,6 +23,7 @@ AR := $$(CROSS_COMPILE_PREFIX)ar
 OBJCOPY := $$(CROSS_COMPILE_PREFIX)objcopy
 
 PROTOC := /usr/local/$$(TARGET_ARCH)/bin/protoc
+WEST := /usr/local/bin/west
 
 OBJDIR := $$(OBJDIR_PREFIX)$$(TGT)
 endef

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -13,23 +13,23 @@ BOARD_PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)/$(BOARD)
 # For top Makefile
 OBJ_SUBDIRS += $(BOARD_PRODUCT_OBJDIR)
 
+# Location of built file. Same location also has .bin, .hex and .map files.
+# But since same instance of $(WEST) generates all, use only .elf file as target.
 ELF := $(BOARD_PRODUCT_OBJDIR)/zephyr/zephyr.elf
-BIN := $(ELF:%.elf=%.bin)
-HEX := $(ELF:%.elf=%.hex)
-LD_MAP := $(ELF:%.elf=%.map)
 
-.PHONY: $(ELF) $(BIN) $(HEX) $(LD_MAP)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: BOARD := $(BOARD)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: PRODIR := $(PRODIR)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
-$(ELF) $(BIN) $(HEX) $(LD_MAP): | $(BOARD_PRODUCT_OBJDIR)
+# Maybe this target should depend on buncha files from a zephyr app
+.PHONY: $(ELF)
+$(ELF):: BOARD := $(BOARD)
+$(ELF):: PRODIR := $(PRODIR)
+$(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
+$(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
+$(ELF): | $(BOARD_PRODUCT_OBJDIR)
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
 	fi;
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1
 
-all.$(PRODUCT): $(ELF) $(BIN) $(HEX) $(LD_MAP)
+all.$(PRODUCT): $(ELF)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -24,10 +24,7 @@ $(ELF):: PRODIR := $(PRODIR)
 $(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 $(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
 $(ELF): | $(BOARD_PRODUCT_OBJDIR)
-	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
-	fi;
-	@echo "Creating $@"
+	@echo "Creating $@ (LOGS: $(BUILD_LOG))"
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -1,0 +1,38 @@
+ifdef ZEPHYR_APP
+
+# Override to use appropriate $(OBJDIR) location (toolchain is already selected by buildenv)
+$(eval $(call inc_toolchain,firmware))
+
+# This file defines rules for targets: [all|clean].$(PRODUCT)
+PRODUCT := $(ZEPHYR_APP)
+# For top Makefile
+PRODUCTS += $(PRODUCT)
+PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+
+# For top Makefile
+OBJ_SUBDIRS += $(PRODUCT_OBJDIR)
+
+ELF := $(PRODUCT_OBJDIR)/zephyr/zephyr.elf
+BIN := $(ELF:%.elf=%.bin)
+HEX := $(ELF:%.elf=%.hex)
+LD_MAP := $(ELF:%.elf=%.map)
+
+.PHONY: $(ELF) $(BIN) $(HEX) $(LD_MAP)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: BOARD := $(BOARD)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: PRODIR := $(PRODIR)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: BUILD_LOG := $(PRODUCT_OBJDIR)/build.log
+$(ELF) $(BIN) $(HEX) $(LD_MAP): | $(PRODUCT_OBJDIR)
+	@if [ "$(VERBOSE)" -ge "1" ]; then \
+		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
+	fi;
+	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1
+
+all.$(PRODUCT): $(ELF) $(BIN) $(HEX) $(LD_MAP)
+
+clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+clean.$(PRODUCT):
+	@echo "Removing $(PRODUCT_OBJDIR)"
+	$(Q)rm -rf $(PRODUCT_OBJDIR)
+
+endif  # ifdef ZEPHYR_APP

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -8,11 +8,12 @@ PRODUCT := $(ZEPHYR_APP)
 # For top Makefile
 PRODUCTS += $(PRODUCT)
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+BOARD_PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)/$(BOARD)
 
 # For top Makefile
-OBJ_SUBDIRS += $(PRODUCT_OBJDIR)
+OBJ_SUBDIRS += $(BOARD_PRODUCT_OBJDIR)
 
-ELF := $(PRODUCT_OBJDIR)/zephyr/zephyr.elf
+ELF := $(BOARD_PRODUCT_OBJDIR)/zephyr/zephyr.elf
 BIN := $(ELF:%.elf=%.bin)
 HEX := $(ELF:%.elf=%.hex)
 LD_MAP := $(ELF:%.elf=%.map)
@@ -20,19 +21,21 @@ LD_MAP := $(ELF:%.elf=%.map)
 .PHONY: $(ELF) $(BIN) $(HEX) $(LD_MAP)
 $(ELF) $(BIN) $(HEX) $(LD_MAP):: BOARD := $(BOARD)
 $(ELF) $(BIN) $(HEX) $(LD_MAP):: PRODIR := $(PRODIR)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
-$(ELF) $(BIN) $(HEX) $(LD_MAP):: BUILD_LOG := $(PRODUCT_OBJDIR)/build.log
-$(ELF) $(BIN) $(HEX) $(LD_MAP): | $(PRODUCT_OBJDIR)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
+$(ELF) $(BIN) $(HEX) $(LD_MAP):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
+$(ELF) $(BIN) $(HEX) $(LD_MAP): | $(BOARD_PRODUCT_OBJDIR)
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
 	fi;
-	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1
+	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1
 
 all.$(PRODUCT): $(ELF) $(BIN) $(HEX) $(LD_MAP)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+clean.$(PRODUCT):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(PRODUCT_OBJDIR)"
-	$(Q)rm -rf $(PRODUCT_OBJDIR)
+	@echo "Removing $(BOARD_PRODUCT_OBJDIR)"
+	$(Q)rm -rf $(BOARD_PRODUCT_OBJDIR)
+	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # ifdef ZEPHYR_APP

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -17,7 +17,7 @@ OBJ_SUBDIRS += $(BOARD_PRODUCT_OBJDIR)
 # But since same instance of $(WEST) generates all, use only .elf file as target.
 ELF := $(BOARD_PRODUCT_OBJDIR)/zephyr/zephyr.elf
 
-# Maybe this target should depend on buncha files from a zephyr app
+# Maybe this target should depend on buncha files from a zephyr app instead
 .PHONY: $(ELF)
 $(ELF):: BOARD := $(BOARD)
 $(ELF):: PRODIR := $(PRODIR)
@@ -27,6 +27,7 @@ $(ELF): | $(BOARD_PRODUCT_OBJDIR)
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
 	fi;
+	@echo "Creating $@"
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -27,7 +27,7 @@ $(ELF): | $(BOARD_PRODUCT_OBJDIR)
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
 		echo "Building $@ (LOGS: $(BUILD_LOG))"; \
 	fi;
-	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1
+	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := nucleo libs zephyr
+SUBDIRS := libs nucleo zephyr
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := nucleo libs
+SUBDIRS := nucleo libs zephyr
 include Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/zephyr/Makefile
+++ b/firmware/zephyr/Makefile
@@ -1,0 +1,4 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+SUBDIRS := hello_world
+include Makefile.defs
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/zephyr/Makefile.defs
+++ b/firmware/zephyr/Makefile.defs
@@ -1,0 +1,1 @@
+../../Makefile.defs

--- a/firmware/zephyr/hello_world/CMakeLists.txt
+++ b/firmware/zephyr/hello_world/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.13.1)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(hello_world.zapp)
+
+target_sources(app PRIVATE src/main.c)

--- a/firmware/zephyr/hello_world/CMakeLists.txt
+++ b/firmware/zephyr/hello_world/CMakeLists.txt
@@ -3,6 +3,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(hello_world.zapp)
+project(hello_world)
 
 target_sources(app PRIVATE src/main.c)

--- a/firmware/zephyr/hello_world/Makefile
+++ b/firmware/zephyr/hello_world/Makefile
@@ -1,0 +1,9 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+# This should be same as project() name in CMakeLists.txt but can be any name
+ZEPHYR_APP := $(shell find $(THIS_DIR) -name CMakeLists.txt -exec sed -n 's/^project(\([\.-_0-9a-zA-Z]\{1,\}\))$$/\1/p' {} \;)
+
+BOARD := nucleo_f401re
+
+include Makefile.defs
+$(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))

--- a/firmware/zephyr/hello_world/Makefile
+++ b/firmware/zephyr/hello_world/Makefile
@@ -1,9 +1,14 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 # This should be same as project() name in CMakeLists.txt but can be any name
-ZEPHYR_APP := $(shell find $(THIS_DIR) -name CMakeLists.txt -exec sed -n 's/^project(\([\.-_0-9a-zA-Z]\{1,\}\))$$/\1/p' {} \;)
+ZEPHYR_APP_NAME := hello_world.zapp
 
 BOARD := nucleo_f401re
+ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
 
 include Makefile.defs
+$(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))
+
+BOARD := nucleo_f767zi
+ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
 $(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))

--- a/firmware/zephyr/hello_world/Makefile
+++ b/firmware/zephyr/hello_world/Makefile
@@ -1,7 +1,6 @@
-THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+# Recommended convention: ZEPHYR_APP := <project() name>.<BOARD>
 
-# This should be same as project() name in CMakeLists.txt but can be any name
-ZEPHYR_APP_NAME := hello_world.zapp
+ZEPHYR_APP_NAME := hello_world
 
 BOARD := nucleo_f401re
 ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
@@ -9,6 +8,7 @@ ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
 include Makefile.defs
 $(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))
 
-BOARD := nucleo_f767zi
-ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
-$(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))
+# Example: create same app for a different board
+# BOARD := nucleo_f767zi
+# ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
+# $(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))

--- a/firmware/zephyr/hello_world/Makefile.defs
+++ b/firmware/zephyr/hello_world/Makefile.defs
@@ -1,0 +1,1 @@
+../../../Makefile.defs

--- a/firmware/zephyr/hello_world/README.rst
+++ b/firmware/zephyr/hello_world/README.rst
@@ -1,0 +1,33 @@
+.. _hello_world:
+
+Hello World
+###########
+
+Overview
+********
+
+A simple sample that can be used with any :ref:`supported board <boards>` and
+prints "Hello World" to the console.
+
+Building and Running
+********************
+
+This application can be built and executed on QEMU as follows:
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/hello_world
+   :host-os: unix
+   :board: qemu_x86
+   :goals: run
+   :compact:
+
+To build for another board, change "qemu_x86" above to that board's name.
+
+Sample Output
+=============
+
+.. code-block:: console
+
+    Hello World! x86
+
+Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.

--- a/firmware/zephyr/hello_world/prj.conf
+++ b/firmware/zephyr/hello_world/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/firmware/zephyr/hello_world/sample.yaml
+++ b/firmware/zephyr/hello_world/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+  description: Hello World sample, the simplest Zephyr
+    application
+  name: hello world
+common:
+    tags: introduction
+    integration_platforms:
+      - native_posix
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Hello World! (.*)"
+tests:
+  sample.basic.helloworld:
+    tags: introduction

--- a/firmware/zephyr/hello_world/src/main.c
+++ b/firmware/zephyr/hello_world/src/main.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2012-2014 Wind River Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/printk.h>
+
+void main(void)
+{
+	printk("Hello World! %s\n", CONFIG_BOARD);
+}


### PR DESCRIPTION
[zephyr](https://www.zephyrproject.org) is Linux kernel like open source project which implements a RTOS for embedded microcontrollers including for ST micro. It has elegant build system where, similar to Linux kernel, an app (similar to kernel module) can be built external to a zephyr workspace. This commit adds support to build such an app.

Currently, a vanilla zephyr workspace is installed in buildenv with latest release used. This will allow building apps for existing boards. If app needs to be built for a custom board then the [zephyr repo](https://github.com/zephyrproject-rtos/zephyr) can be forked which can then be hosted in the buildenv.

This PR also fixes related but generic build issues involving building at sub-directory levels which were prompted after support to build zephyr-apps were added.

Testing done
- stm-main workspace builds as expected at all directory levels.
- generated zephyr app loads on nucleo_f401re reference board as expected.


NOTE
Since we are not using zephyr toolchain (using env variable `ZEPHYR_SDK_INSTALL_DIR`), `west flash` isn't support ootb. It requires `openocd` (which comes with zephyr toolchain) and  needs to be added in buildenv separately and be supplied with 
```
west flash --openocd-search <path/to/openocd/install>
```