### PR TITLE
build: fine tune verbosity of build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ help:
 	@echo "Commmand-line overrides"
 	@echo "        ARCH: build for a target architecture"
 	@echo "              Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
-	@echo "     VERBOSE: build verbose level"
-	@echo "              Supported: 0 1 2 [Default: 1]"
+	@echo "     VERBOSE: build verbosity"
+	@echo "              On/Off if defined/undefined [Default: not defined]"
 	@echo
 	@echo "Other supported build systems (outside of default build system)"
 	@echo "         ROS: make help.ros"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 # Wrapper useful "clean" targets
 #
 cleanall:
-	@echo "Removing $(OBJDIR_PREFIX)*"
+	@echo "      [RM] $(OBJDIR_PREFIX)*"
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 clobber: cleanall

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ help:
 	@echo "        ARCH: build for a target architecture"
 	@echo "              Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
 	@echo "     VERBOSE: build verbose level"
-	@echo "              Supported: 1 2 [Default: quiet]"
+	@echo "              Supported: 0 1 2 [Default: 1]"
 	@echo
 	@echo "Other supported build systems (outside of default build system)"
 	@echo "         ROS: make help.ros"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 # Wrapper useful "clean" targets
 #
 cleanall:
-	@echo "      [RM] $(OBJDIR_PREFIX)*"
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(OBJDIR_PREFIX)*"
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 clobber: cleanall

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -68,8 +68,7 @@ include $(Makefile.toolchain)
 #
 # Helper command line variable for build debugging
 #
-VERBOSE ?= 1
-ifeq ($(VERBOSE),2)
+ifdef VERBOSE
 Q :=
 else
 Q := @
@@ -203,9 +202,7 @@ $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
-	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@; \
-	fi;
+	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -183,10 +183,10 @@ SUFFIX := $$(suffix $(1))
 
 ifeq ($$(SUFFIX),$$(filter $$(SUFFIX),$$(CC_EXTS)))
 GCC := $$(CXX)
-GCCSTR := "     [CXX]"
+GCCSTR := "[CXX]"
 else ifeq ($$(SUFFIX),.c)
 GCC := $$(CC)
-GCCSTR := "      [CC]"
+GCCSTR := "[CC]"
 # Ignore CXXFLAGS for .c files
 CXXFLAGS :=
 else

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -66,7 +66,7 @@ include $(Makefile.toolchain)
 #
 # Helper command line variable for build debugging
 #
-VERBOSE ?= 0
+VERBOSE ?= 1
 ifeq ($(VERBOSE),2)
 Q :=
 else

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -37,6 +37,8 @@ CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
 # PROTOBUF ARCH dependent CFLAGS and LFLAGS
 PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
 PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
+# Number of colums to print at start of line in build output
+PCOL := 10
 
 #
 # All supported rules
@@ -202,7 +204,7 @@ $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		printf "%s %s\n" $$(GCCSTR) $$@; \
+		printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@; \
 	fi;
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -182,8 +182,10 @@ SUFFIX := $$(suffix $(1))
 
 ifeq ($$(SUFFIX),$$(filter $$(SUFFIX),$$(CC_EXTS)))
 GCC := $$(CXX)
+GCCSTR := "     [CXX]"
 else ifeq ($$(SUFFIX),.c)
 GCC := $$(CC)
+GCCSTR := "      [CC]"
 # Ignore CXXFLAGS for .c files
 CXXFLAGS :=
 else
@@ -194,12 +196,13 @@ endif
 # before adding it as a prefix to "OBJFILE"
 OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(subst $(OBJDIR)/,,$(1)))
 
+$$(OBJFILE):: GCCSTR := $$(GCCSTR)
 $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		echo "Building $$< => $$@"; \
+		printf "%s %s\n" $$(GCCSTR) $$@; \
 	fi;
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -36,14 +36,14 @@ $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 $(BINELF):: CXX := $(CXX)
 $(BINELF):: LFLAGS := $(LFLAGS)
 $(BINELF): $(DEP_AR) $(C_OBJS)
-	@echo "   [CXXLD] $@"
+	@printf "%$(PCOL)s %s\n" "[CXXLD]" $@
 	$(Q)$(CXX) -o $@ $(filter %.o,$^) $(LFLAGS)
 
 all.$(PRODUCT): $(BINELF)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "      [RM] $(PRODUCT_OBJDIR)"
+	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define C_BIN

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -36,14 +36,14 @@ $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
 $(BINELF):: CXX := $(CXX)
 $(BINELF):: LFLAGS := $(LFLAGS)
 $(BINELF): $(DEP_AR) $(C_OBJS)
-	@echo "Creating $@"
+	@echo "   [CXXLD] $@"
 	$(Q)$(CXX) -o $@ $(filter %.o,$^) $(LFLAGS)
 
 all.$(PRODUCT): $(BINELF)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(PRODUCT_OBJDIR)"
+	@echo "      [RM] $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define C_BIN

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -59,20 +59,20 @@ $(foreach hdr,$(I_HDRS),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
 $(LIB_SO):: CXX := $(CXX)
 $(LIB_SO):: LFLAGS := $(LFLAGS)
 $(LIB_SO): $(DEP_SO) $(APIHDR) $(C_OBJS)
-	@echo "   [CXXLD] $@"
+	@printf "%$(PCOL)s %s\n" "[CXXLD]" $@
 	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
 $(LIB_AR):: AR := $(AR)
 $(LIB_AR): $(DEP_AR) $(APIHDR) $(C_OBJS)
-	@echo "      [AR] $@"
+	@printf "%$(PCOL)s %s\n" "[AR]" $@
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "      [RM] $(PRODUCT_OBJDIR)"
+	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define C_LIB

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -59,20 +59,20 @@ $(foreach hdr,$(I_HDRS),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
 $(LIB_SO):: CXX := $(CXX)
 $(LIB_SO):: LFLAGS := $(LFLAGS)
 $(LIB_SO): $(DEP_SO) $(APIHDR) $(C_OBJS)
-	@echo "Creating $@"
+	@echo "   [CXXLD] $@"
 	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
 $(LIB_AR):: AR := $(AR)
 $(LIB_AR): $(DEP_AR) $(APIHDR) $(C_OBJS)
-	@echo "Creating $@"
+	@echo "      [AR] $@"
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(PRODUCT_OBJDIR)"
+	@echo "      [RM] $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define C_LIB

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -29,9 +29,7 @@ define pb_cc_src_tgt
 PB_CC_FILE := $(PRODUCT_OBJDIR)/$(1:%.proto=%.pb.cc)
 
 $$(PB_CC_FILE): $(PRODIR)/$(1) | $$(dir $$(PB_CC_FILE))
-	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		printf "%$(PCOL)s %s\n" "[PROTOC]" $$@; \
-	fi;
+	@printf "%$(PCOL)s %s\n" "[PROTOC]" $$@
 	$(Q)$(PROTOC) -I $(PRODIR) $$^ --cpp_out=$(PRODUCT_OBJDIR)
 
 PB_CC_SRCS += $$(PB_CC_FILE)

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -42,20 +42,20 @@ $(eval $(call add_c_obj_tgts,$(PB_CC_SRCS)))
 $(LIB_SO):: CXX := $(CXX)
 $(LIB_SO):: LFLAGS := $(LFLAGS)
 $(LIB_SO): $(DEP_SO) $(PB_CC_OBJS)
-	@echo "Creating $@"
+	@echo "   [CXXLD] $@"
 	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
 $(LIB_AR): AR := $(AR)
 $(LIB_AR): $(DEP_AR) $(PB_CC_OBJS)
-	@echo "Creating $@"
+	@echo "      [AR] $@"
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(PRODUCT_OBJDIR)"
+	@echo "      [RM] $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -29,6 +29,9 @@ define pb_cc_src_tgt
 PB_CC_FILE := $(PRODUCT_OBJDIR)/$(1:%.proto=%.pb.cc)
 
 $$(PB_CC_FILE): $(PRODIR)/$(1) | $$(dir $$(PB_CC_FILE))
+	@if [ "$(VERBOSE)" -ge "1" ]; then \
+		printf "%$(PCOL)s %s\n" "[PROTOC]" $$@; \
+	fi;
 	$(Q)$(PROTOC) -I $(PRODIR) $$^ --cpp_out=$(PRODUCT_OBJDIR)
 
 PB_CC_SRCS += $$(PB_CC_FILE)
@@ -42,20 +45,20 @@ $(eval $(call add_c_obj_tgts,$(PB_CC_SRCS)))
 $(LIB_SO):: CXX := $(CXX)
 $(LIB_SO):: LFLAGS := $(LFLAGS)
 $(LIB_SO): $(DEP_SO) $(PB_CC_OBJS)
-	@echo "   [CXXLD] $@"
+	@printf "%$(PCOL)s %s\n" "[CXXLD]" $@
 	$(Q)$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 # Build dep .a first
 $(LIB_AR): AR := $(AR)
 $(LIB_AR): $(DEP_AR) $(PB_CC_OBJS)
-	@echo "      [AR] $@"
+	@printf "%$(PCOL)s %s\n" "[AR]" $@
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "      [RM] $(PRODUCT_OBJDIR)"
+	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif

--- a/build/Makefile.ros
+++ b/build/Makefile.ros
@@ -41,7 +41,7 @@ clean.$(ROS2_DISTRO):
 
 help.ros:
 	@echo "ROS Targets (cross-compilation not supported)"
-	@echo "           $(ROS1_DISTRO): Build ROS2 ($(ROS1_DISTRO)) packages"
+	@echo "           $(ROS1_DISTRO): Build ROS1 ($(ROS1_DISTRO)) packages"
 	@echo "     clean.$(ROS1_DISTRO): rm -rf $(notdir $(NOETIC_WS))/{build,install,devel}"
 	@echo "             $(ROS2_DISTRO): Build ROS2 ($(ROS2_DISTRO)) packages"
 	@echo "       clean.$(ROS2_DISTRO): rm -rf $(notdir $(FOXY_WS))/{build,install,log}"

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -42,9 +42,7 @@ define S_OBJ_TGT
 $(1):: CC := $$(CC)
 $(1):: CFLAGS := $$(CFLAGS)
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))
-	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		printf "%$(PCOL)s %s\n" "[CC]" $$@; \
-	fi;
+	@printf "%$(PCOL)s %s\n" "[CC]" $$@
 	$(Q)$$(CC) $$(CFLAGS) -c $$< -o $$@
 endef
 $(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -53,7 +53,7 @@ $(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))
 $(ELF):: CC := $(CC)
 $(ELF):: LFLAGS := $(LFLAGS)
 $(ELF): $(LD_SRC) $(DEP_AR) $(C_OBJS) $(S_OBJS)
-	@echo "      [CC] $@"
+	@echo "    [CCLD] $@"
 	$(Q)$(CC) -T $(filter %.ld,$^) $(filter %.o,$^) $(LFLAGS) -o $@
 
 $(BIN):: OBJCOPY := $(OBJCOPY)

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -43,7 +43,7 @@ $(1):: CC := $$(CC)
 $(1):: CFLAGS := $$(CFLAGS)
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		echo "Building $$< => $$@"; \
+		echo "      [CC] $$@"; \
 	fi;
 	$(Q)$$(CC) $$(CFLAGS) -c $$< -o $$@
 endef
@@ -53,24 +53,24 @@ $(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))
 $(ELF):: CC := $(CC)
 $(ELF):: LFLAGS := $(LFLAGS)
 $(ELF): $(LD_SRC) $(DEP_AR) $(C_OBJS) $(S_OBJS)
-	@echo "Creating $@"
+	@echo "      [CC] $@"
 	$(Q)$(CC) -T $(filter %.ld,$^) $(filter %.o,$^) $(LFLAGS) -o $@
 
 $(BIN):: OBJCOPY := $(OBJCOPY)
 $(BIN): $(ELF)
-	@echo "Creating $@"
+	@echo " [OBJCOPY] $@"
 	$(Q)$(OBJCOPY) -Obinary $^ $@
 
 $(HEX):: OBJCOPY := $(OBJCOPY)
 $(HEX): $(ELF)
-	@echo "Creating $@"
+	@echo " [OBJCOPY] $@"
 	$(Q)$(OBJCOPY) -Oihex $^ $@
 
 all.$(PRODUCT): $(ELF) $(BIN) $(HEX)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(PRODUCT_OBJDIR)"
+	@echo "      [RM] $(PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define STM32_ELF

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -43,7 +43,7 @@ $(1):: CC := $$(CC)
 $(1):: CFLAGS := $$(CFLAGS)
 $(1): $(subst $(OBJDIR)/,,$(1:%.o=%.s)) | $(dir $(1))
 	@if [ "$(VERBOSE)" -ge "1" ]; then \
-		echo "      [CC] $$@"; \
+		printf "%$(PCOL)s %s\n" "[CC]" $$@; \
 	fi;
 	$(Q)$$(CC) $$(CFLAGS) -c $$< -o $$@
 endef
@@ -53,24 +53,24 @@ $(foreach OBJFILE,$(S_OBJS),$(eval $(call S_OBJ_TGT,$(OBJFILE))))
 $(ELF):: CC := $(CC)
 $(ELF):: LFLAGS := $(LFLAGS)
 $(ELF): $(LD_SRC) $(DEP_AR) $(C_OBJS) $(S_OBJS)
-	@echo "    [CCLD] $@"
+	@printf "%$(PCOL)s %s\n" "[CCLD]" $@
 	$(Q)$(CC) -T $(filter %.ld,$^) $(filter %.o,$^) $(LFLAGS) -o $@
 
 $(BIN):: OBJCOPY := $(OBJCOPY)
 $(BIN): $(ELF)
-	@echo " [OBJCOPY] $@"
+	@printf "%$(PCOL)s %s\n" "[OBJCOPY]" $@
 	$(Q)$(OBJCOPY) -Obinary $^ $@
 
 $(HEX):: OBJCOPY := $(OBJCOPY)
 $(HEX): $(ELF)
-	@echo " [OBJCOPY] $@"
+	@printf "%$(PCOL)s %s\n" "[OBJCOPY]" $@
 	$(Q)$(OBJCOPY) -Oihex $^ $@
 
 all.$(PRODUCT): $(ELF) $(BIN) $(HEX)
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "      [RM] $(PRODUCT_OBJDIR)"
+	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
 	$(Q)rm -rf $(PRODUCT_OBJDIR)
 
 endif  # define STM32_ELF

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -17,13 +17,14 @@ OBJ_SUBDIRS += $(BOARD_PRODUCT_OBJDIR)
 # But since same instance of $(WEST) generates all, use only .elf file as target.
 ELF := $(BOARD_PRODUCT_OBJDIR)/zephyr/zephyr.elf
 
-# Maybe this target should depend on buncha files from a zephyr app instead
-.PHONY: $(ELF)
+# List of files as dependency to build $(ELF)
+ZEPHYR_APP_DEP_FILES := $(shell find $(PRODIR) -name "*.[c|h]" -o -name "*.proto" -o -name "CMakeLists.txt" -o -name "prj.conf")
+
 $(ELF):: BOARD := $(BOARD)
 $(ELF):: PRODIR := $(PRODIR)
 $(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 $(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
-$(ELF): | $(BOARD_PRODUCT_OBJDIR)
+$(ELF): $(ZEPHYR_APP_DEP_FILES) | $(BOARD_PRODUCT_OBJDIR)
 	@printf "%$(PCOL)s %s\n" "[WEST]" $@
 	@printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -24,7 +24,8 @@ $(ELF):: PRODIR := $(PRODIR)
 $(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 $(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
 $(ELF): | $(BOARD_PRODUCT_OBJDIR)
-	@echo "Creating $@ (LOGS: $(BUILD_LOG))"
+	@echo "    [WEST] $@"
+	@echo "           Logs: $(BUILD_LOG)"
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)
@@ -32,7 +33,7 @@ all.$(PRODUCT): $(ELF)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "Removing $(BOARD_PRODUCT_OBJDIR)"
+	@echo "        [RM] $(BOARD_PRODUCT_OBJDIR)"
 	$(Q)rm -rf $(BOARD_PRODUCT_OBJDIR)
 	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -24,8 +24,8 @@ $(ELF):: PRODIR := $(PRODIR)
 $(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 $(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
 $(ELF): | $(BOARD_PRODUCT_OBJDIR)
-	@echo "    [WEST] $@"
-	@echo "           Logs: $(BUILD_LOG)"
+	@printf "%$(PCOL)s %s\n" "[WEST]" $@
+	@printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)
@@ -33,7 +33,7 @@ all.$(PRODUCT): $(ELF)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@echo "        [RM] $(BOARD_PRODUCT_OBJDIR)"
+	@printf "%$(PCOL)s %s\n" "[RM]" $(BOARD_PRODUCT_OBJDIR)
 	$(Q)rm -rf $(BOARD_PRODUCT_OBJDIR)
 	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -25,8 +25,8 @@ $(ELF):: PRODIR := $(PRODIR)
 $(ELF):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)
 $(ELF):: BUILD_LOG := $(BOARD_PRODUCT_OBJDIR)/build.log
 $(ELF): $(ZEPHYR_APP_DEP_FILES) | $(BOARD_PRODUCT_OBJDIR)
-	@printf "%$(PCOL)s %s\n" "[WEST]" $@
-	@printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
+	@printf "%$(PCOL)s %s\n" "[WEST]" $@ && \
+		printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
 	$(Q)$(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)

--- a/cmds/common/pb_example/Makefile
+++ b/cmds/common/pb_example/Makefile
@@ -8,7 +8,7 @@ H_DIRS :=
 C_SRCS := src/add_person.cc
 
 # "deps"
-DEPEND := cmds/common/pb_example/proto:address_book
+DEPEND := cmds/common/pb_example/proto:addressbook
 
 CFLAGS += $(PROTOBUF_CFLAGS)
 LFLAGS += $(PROTOBUF_LFLAGS)
@@ -20,7 +20,7 @@ $(eval $(call inc_rule,cbin,$(C_BIN)))
 C_BIN := list_people
 H_DIRS :=
 C_SRCS := src/list_people.cc
-DEPEND := cmds/common/pb_example/proto:address_book
+DEPEND := cmds/common/pb_example/proto:addressbook
 CFLAGS += $(PROTOBUF_CFLAGS)
 LFLAGS += $(PROTOBUF_LFLAGS)
 $(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/cmds/common/pb_example/proto/Makefile
+++ b/cmds/common/pb_example/proto/Makefile
@@ -1,4 +1,4 @@
-PROTO_LIB := address_book
+PROTO_LIB := addressbook
 
 PB_SRCS := addressbook.proto
 


### PR DESCRIPTION
Build output is slightly messy. Tune it and make it somewhat "conventional" by print `[CC]` (or `[CXX]`) for build stage and `[CCLD]` (or `[CXXLD]`) for linking stage and similar short names for other commands.

Also eliminated "VERBOSE level" method which had following intentions:
```
VERBOSE=0 prints link stage only
VERBOSE=1 prints link + build stages
VERBOSE=2 prints link + build + actual command at each stage
```
This is **changed** to simple "VERBOSE on/off" method where if VERBOSE is defined, it'll act as `VERBOSE=2`. Default is **off** which is same as `VERBOSE=1`. No such thing as `VERBOSE=0`.

Tested to ensure the updated verbosity as expected when defined and not defined.