### PR TITLE
build: fixes issue when same target is built from different directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,5 @@ help:
 	@echo
 	@echo "Other supported build systems (outside of default build system)"
 	@echo "         ROS: make help.ros"
+
+.SILENT:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBJ_SUBDIRS :=
 #
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := firmware libs cmds
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
 
 #

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,8 +1,8 @@
 #
 # @file: Makefile that defines absolute paths and macro definitions for
-#        the build system for the repo. A symlink to this file must
-#        exist at each directory level of this repo to allow invoking
-#        and building at any sub-directory level.
+#        the build system for the repo. It is included at each directory
+#        level of this repo to allow invoking and building at any
+#        sub-directory level.
 #
 
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -154,7 +154,7 @@ DEF_TARGETS := 1
 
 $(MAKECMDGOALS): $$(TARGETS)
 $$(TARGETS):
-	$(Q)$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
+	$(Q)$$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
 endif
 
 else
@@ -246,11 +246,14 @@ DIFF_FLAGS := CFLAGS LFLAGS CXXFLAGS
 METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.$(1).mk
 METADATA_FILE_TMP := $$(METADATA_FILE:%=%.tmp)
 
+$$(METADATA_FILE):: CFLAGS := $(CFLAGS)
+$$(METADATA_FILE):: LFLAGS := $(LFLAGS)
+$$(METADATA_FILE):: CXXFLAGS := $(CXXFLAGS)
 $$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
 $$(METADATA_FILE): clean_$$(METADATA_FILE_TMP) | $(PRODUCT_OBJDIR)
 	$$(foreach flag,$$(DIFF_FLAGS),$$(shell eval "echo $$(flag) := $$($$(flag)) >> $$(METADATA_FILE_TMP)"))
 	@if [ ! -f $$@ ] || ! diff $$@ $$(METADATA_FILE_TMP) >/dev/null; then \
-		[ -f $$@ ] && echo "$(1): Flags changed"; \
+		[ -f $$@ ] && printf "%$(PCOL)s %s\n" "[=>]" "$$(@D)/$(1) [flags changed]"; \
 		mv $$(METADATA_FILE_TMP) $$@; \
 	else \
 		rm $$(METADATA_FILE_TMP); \

--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := common
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/Makefile.defs
+++ b/cmds/Makefile.defs
@@ -1,1 +1,0 @@
-../Makefile.defs

--- a/cmds/common/Makefile
+++ b/cmds/common/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := hello_world hello_world_cpp pb_example
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/cmds/common/Makefile.defs
+++ b/cmds/common/Makefile.defs
@@ -1,1 +1,0 @@
-../../Makefile.defs

--- a/cmds/common/hello_world/Makefile
+++ b/cmds/common/hello_world/Makefile
@@ -8,5 +8,5 @@ C_SRCS := src/hello_world.c
 # "deps"
 DEPEND := libs/common/hello:hello
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/cmds/common/hello_world/Makefile.defs
+++ b/cmds/common/hello_world/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/cmds/common/hello_world_cpp/Makefile
+++ b/cmds/common/hello_world_cpp/Makefile
@@ -8,5 +8,5 @@ C_SRCS := src/hello_world.cpp
 # "deps"
 DEPEND := libs/common/hello_cpp:hello_cpp
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/cmds/common/hello_world_cpp/Makefile.defs
+++ b/cmds/common/hello_world_cpp/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/cmds/common/pb_example/Makefile
+++ b/cmds/common/pb_example/Makefile
@@ -13,7 +13,7 @@ DEPEND := cmds/common/pb_example/proto:addressbook
 CFLAGS += $(PROTOBUF_CFLAGS)
 LFLAGS += $(PROTOBUF_LFLAGS)
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,cbin,$(C_BIN)))
 
 # add another C_BIN

--- a/cmds/common/pb_example/Makefile.defs
+++ b/cmds/common/pb_example/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/cmds/common/pb_example/proto/Makefile
+++ b/cmds/common/pb_example/proto/Makefile
@@ -4,5 +4,5 @@ PB_SRCS := addressbook.proto
 
 DEPEND :=
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,protobuf,$(PROTO_LIB)))

--- a/cmds/common/pb_example/proto/Makefile.defs
+++ b/cmds/common/pb_example/proto/Makefile.defs
@@ -1,1 +1,0 @@
-../../../../Makefile.defs

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := libs nucleo zephyr
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/Makefile.defs
+++ b/firmware/Makefile.defs
@@ -1,1 +1,0 @@
-../Makefile.defs

--- a/firmware/libs/FreeRTOS/Makefile
+++ b/firmware/libs/FreeRTOS/Makefile
@@ -23,7 +23,7 @@ INC_PREFIX :=
 CFLAGS += $(STM32_CFLAGS)
 CFLAGS += -mthumb-interwork -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -std=gnu90 -ffunction-sections -fdata-sections
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 
 # Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location
 $(eval $(call inc_toolchain,firmware))

--- a/firmware/libs/FreeRTOS/Makefile.defs
+++ b/firmware/libs/FreeRTOS/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/firmware/libs/Makefile
+++ b/firmware/libs/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := FreeRTOS
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/libs/Makefile.defs
+++ b/firmware/libs/Makefile.defs
@@ -1,1 +1,0 @@
-../../Makefile.defs

--- a/firmware/nucleo/Lidar_Delivery/Makefile
+++ b/firmware/nucleo/Lidar_Delivery/Makefile
@@ -6,5 +6,5 @@ C_SRCS := $(shell find $(THIS_DIR) -name "*.c" -printf "%P\n" 2>/dev/null | sed 
 S_SRCS := $(shell find $(THIS_DIR) -name "*.s" -printf "%P\n" 2>/dev/null | sed "s|^\./||")
 LD_SRC := LinkerScript.ld
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,stm32,$(STM32_ELF)))

--- a/firmware/nucleo/Lidar_Delivery/Makefile.defs
+++ b/firmware/nucleo/Lidar_Delivery/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/firmware/nucleo/Makefile
+++ b/firmware/nucleo/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := Lidar_Delivery
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/nucleo/Makefile.defs
+++ b/firmware/nucleo/Makefile.defs
@@ -1,1 +1,0 @@
-../../Makefile.defs

--- a/firmware/zephyr/Makefile
+++ b/firmware/zephyr/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := hello_world
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/firmware/zephyr/Makefile.defs
+++ b/firmware/zephyr/Makefile.defs
@@ -1,1 +1,0 @@
-../../Makefile.defs

--- a/firmware/zephyr/hello_world/Makefile
+++ b/firmware/zephyr/hello_world/Makefile
@@ -5,7 +5,7 @@ ZEPHYR_APP_NAME := hello_world
 BOARD := nucleo_f401re
 ZEPHYR_APP := $(ZEPHYR_APP_NAME).$(BOARD)
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,zephyr,$(ZEPHYR_APP)))
 
 # Example: create same app for a different board

--- a/firmware/zephyr/hello_world/Makefile.defs
+++ b/firmware/zephyr/hello_world/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := common
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/Makefile.defs
+++ b/libs/Makefile.defs
@@ -1,1 +1,0 @@
-../Makefile.defs

--- a/libs/common/Makefile
+++ b/libs/common/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := hello hello_cpp
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/common/Makefile.defs
+++ b/libs/common/Makefile.defs
@@ -1,1 +1,0 @@
-../../Makefile.defs

--- a/libs/common/hello/Makefile
+++ b/libs/common/hello/Makefile
@@ -16,5 +16,5 @@ STRIP_INC_PREFIX := inc
 # include_prefix
 INC_PREFIX := libhello
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/common/hello/Makefile.defs
+++ b/libs/common/hello/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs

--- a/libs/common/hello_cpp/Makefile
+++ b/libs/common/hello_cpp/Makefile
@@ -16,5 +16,5 @@ STRIP_INC_PREFIX := inc
 # include_prefix
 INC_PREFIX := libhello_cpp
 
-include Makefile.defs
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/common/hello_cpp/Makefile.defs
+++ b/libs/common/hello_cpp/Makefile.defs
@@ -1,1 +1,0 @@
-../../../Makefile.defs


### PR DESCRIPTION
- Fixes multithreaded make when called from a sub-directory
- Added .SILENT to top Makefile

Target to detect "c flags" didn't make a copy of those flags for it which caused the flags to be different for the same target when the target is built from different directories (e.g. top-dir vs from a sub-dir). Fixed that issue. Also improved build output that's printed when flag change is detected.

Tested that the issue is fixed with target from top-dir and sub-dir and verified that it is executed only when there are changes in "c flags". Also tested multi-threaded make (`make -j N`) works as expected when `make` is called from a sub-directory.


On a separate commit, eliminated need for `Makefile.defs` at each level to remove a logistics detail when adding new sub-directories. It is included using absolute path using `git rev-parse --show-toplevel`.