### PR TITLE
build: added ease-of-use targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,19 +72,25 @@ include $(Makefile.ros)
 
 help:
 	@echo "Build Targets"
-	@echo "         all: build all $(ARCH) products (default)"
-	@echo "       clean: remove all previously built $(ARCH) products"
-	@echo "    cleanall: remove all products for all targets architectues"
-	@echo "     clobber: cleanall + remove cscope/ctags"
-	@echo "        help: show this message"
+	@echo "          all: build all $(ARCH) products (default)"
+	@echo "        clean: remove all previously built $(ARCH) products"
+	@echo "     cleanall: remove all products for all targets architectues"
+	@echo "      clobber: cleanall + remove cscope/ctags"
+	@echo "         help: show this message"
+	@echo "<path>[:prod]: build all $(ARCH) products for <path> and subdirs below"
+	@echo "               if specified, build only the product "prod" in the <path>"
+	@echo "               Specify \"clean=1\" to clean (Supported: all|clean)"
+	@echo "               For example, make libs/common"
+	@echo "                            make cmds/common/pb_example:list_people"
+	@echo "                            make libs/common clean=1"
 	@echo
 	@$(MAKE) --no-print-directory help.buildenv
 	@echo
 	@echo "Commmand-line overrides"
-	@echo "        ARCH: build for a target architecture"
-	@echo "              Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
-	@echo "     VERBOSE: build verbosity"
-	@echo "              On/Off if defined/undefined [Default: not defined]"
+	@echo "         ARCH: build for a target architecture"
+	@echo "               Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
+	@echo "      VERBOSE: build verbosity"
+	@echo "               On/Off if defined/undefined [Default: not defined]"
 	@echo
 	@echo "Other supported build systems (outside of default build system)"
-	@echo "         ROS: make help.ros"
+	@echo "          ROS: make help.ros"

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ cleanall:
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 clobber: cleanall
-	@printf "%$(PCOL)s %s\n" "[RM]" "cscope files, tags"
+	@printf "%$(PCOL)s %s\n" "[RM]" "cscope.* tags"
 	$(Q)rm -f cscope.* tags
 
 .DEFAULT_GOAL := all

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,12 @@ $(sort $(OBJ_SUBDIRS)):
 all: $(patsubst %,all.%,$(PRODUCTS))
 ifeq ("$(origin ARCH)","command line")
 clean:
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(OBJDIR_PREFIX)$(ARCH)"
 	$(Q)rm -rf $(OBJDIR_PREFIX)$(ARCH)
 else
-clean: $(patsubst %,clean.%,$(PRODUCTS))
+clean:
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(OBJDIR_PREFIX){$(ARCH),firmware}"
+	$(Q)rm -rf $(OBJDIR_PREFIX){$(ARCH),firmware}
 endif
 
 #
@@ -60,6 +63,7 @@ cleanall:
 	$(Q)rm -rf $(OBJDIR_PREFIX)*
 
 clobber: cleanall
+	@printf "%$(PCOL)s %s\n" "[RM]" "cscope files, tags"
 	$(Q)rm -f cscope.* tags
 
 .DEFAULT_GOAL := all
@@ -79,7 +83,7 @@ help:
 	@echo "         help: show this message"
 	@echo "<path>[:prod]: build all $(ARCH) products for <path> and subdirs below"
 	@echo "               if specified, build only the product "prod" in the <path>"
-	@echo "               Specify \"clean=1\" to clean (Supported: all|clean)"
+	@echo "               Specify \"clean=1\" to clean"
 	@echo "               For example, make libs/common"
 	@echo "                            make cmds/common/pb_example:list_people"
 	@echo "                            make libs/common clean=1"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -78,13 +78,7 @@ Q := @
 endif
 
 
-#
-# Macro to include a sub-directory
-#
-define subdirs
-PRODIR := $(1)
-OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
-
+define restore_defaults
 #
 # Set toolchain for the subdir and the ones below it. This can be overridden by
 # each individual directory
@@ -100,6 +94,21 @@ $$(foreach RULE,$(ALL_RULES),$$(eval $$(RULE) := ))
 # Clean the slate: reset attributes for all rules
 #
 $$(foreach ATTR,$(ALL_ATTRS),$$(eval $$(ATTR) := ))
+endef
+
+
+#
+# Macro to include a sub-directory
+#
+define subdirs
+PRODIR := $(1)
+OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
+
+#
+# Clean the slate: undef all rules and their attributes +
+#                  include toolchain for $$(ARCH)
+#
+$$(eval $$(call restore_defaults))
 
 #
 # While we are here, define ease-of-use target for this subdir
@@ -170,14 +179,10 @@ include $(Makefile.$(1))
 endif
 
 #
-# Clean the slate: reset attributes for all rules
+# Clean the slate: undef all rules and their attributes +
+#                  include toolchain for $$(ARCH)
 #
-$$(foreach ATTR,$(ALL_ATTRS),$$(eval $$(ATTR) := ))
-
-#
-# Reset back to original toolchain
-#
-$$(eval $$(call inc_toolchain,$$(ARCH)))
+$$(eval $$(call restore_defaults))
 endef
 
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -289,6 +289,6 @@ define del_empty_dirs
 	while true; do \
 		empty_dirs=$$(find $(1) -type d -empty 2>/dev/null); \
 		[ -z "$$empty_dirs" ] && break; \
-		rmdir $$empty_dirs; \
+		rmdir $$empty_dirs 2>/dev/null || true; \
 	done;
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -104,8 +104,9 @@ $$(foreach ATTR,$(ALL_ATTRS),$$(eval $$(ATTR) := ))
 #
 # While we are here, define ease-of-use target for this directory
 #
-.PHONY: $$(PRODIR) $$(PRODIR)/
-$$(PRODIR) $$(PRODIR)/:
+DIR_TGT := $$(PRODIR) $$(PRODIR)/
+.PHONY: $$(DIR_TGT)
+$$(DIR_TGT):
 	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,)
 
 include $(1)/Makefile

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -122,7 +122,7 @@ ifneq ($(TOPDIR),)
 DIR_TGT := $$(PRODIR) $$(PRODIR)/
 .PHONY: $$(DIR_TGT)
 $$(DIR_TGT):
-	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,)
+	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,all)
 endif
 
 include $(1)/Makefile
@@ -169,7 +169,7 @@ DEF_TARGETS := 1
 _all_ := $$(if $$(MAKECMDGOALS),$$(MAKECMDGOALS),$$(TARGETS))
 .DEFAULT_GOAL := $$(_all_)
 $$(_all_):
-	$(Q)$$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
+	$(Q)$$(MAKE) --no-print-directory -C $$(_TOPDIR_) $$(TARGETS)
 endif
 
 else

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -102,40 +102,26 @@ $$(foreach RULE,$(ALL_RULES),$$(eval $$(RULE) := ))
 $$(foreach ATTR,$(ALL_ATTRS),$$(eval $$(ATTR) := ))
 
 #
-# While we are here, define ease-of-use target for this directory
+# While we are here, define ease-of-use target for this subdir
+# but only when invoked from TOPDIR to define targets for
+# subdir paths relative to TOPDIR only
 #
+ifneq ($(TOPDIR),)
 DIR_TGT := $$(PRODIR) $$(PRODIR)/
 .PHONY: $$(DIR_TGT)
 $$(DIR_TGT):
 	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,)
+endif
 
 include $(1)/Makefile
 endef
 
 
 #
-# Wrapper macro to "subdirs" macro. Depending upon which directory "$(MAKE)"
-# is invoked upon, this macro will either simply include subdirectories or
-# recursively find all the "Makefile" from directories below and include them.
+# Wrapper macro to "subdirs" macro to include multiple sub-directories
 #
 define inc_subdir
-ifeq ($(TOPDIR),)
-# This method won't honor if a subdir is present but isn't
-# enlisted in the makefile of the parent dir
-MKFILES += $(shell find $(1) -mindepth 2 -name Makefile)
-
-#
-# Accumulated makefiles need to be included only once;
-# use sort to enumuerate unique ones.
-#
-ifndef INC_MAKEFILE
-INC_MAKEFILE := 1
-$$(foreach makefile,$$(sort $$(MKFILES)),$$(eval include $$(makefile)))
-endif
-
-else
 $$(foreach SUBDIR,$(2:%=$(1)%),$$(eval $$(call subdirs,$$(SUBDIR))))
-endif
 endef
 
 
@@ -167,10 +153,12 @@ endif
 ifndef DEF_TARGETS
 DEF_TARGETS := 1
 
-ifneq ($(MAKECMDGOALS),$$(TARGETS))
-$(MAKECMDGOALS): $$(TARGETS)
-endif
-$$(TARGETS):
+# Establish default goal when invoked from subdir (instead of TOPDIR).
+# Whether goal is specified or not the action remains the same:
+# execute $$(TARGETS) from TOPDIR
+_all_ := $$(if $$(MAKECMDGOALS),$$(MAKECMDGOALS),$$(TARGETS))
+.DEFAULT_GOAL := $$(_all_)
+$$(_all_):
 	$(Q)$$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
 endif
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -151,6 +151,10 @@ ifeq ($(TOPDIR),)
 #
 ifeq ($(MAKECMDGOALS),)
 TARGETS += all.$(2)
+else ifeq ($(filter all clean clean=,$(MAKECMDGOALS)),)
+# Only "all|clean" goals are supported from all dir-levels. Any other goals are
+# simply run from TOPDIR w/o accumulation and conversion for actual targets
+TARGETS := $(MAKECMDGOALS)
 else
 TARGETS += $(MAKECMDGOALS:%=%.$(2))
 endif
@@ -163,7 +167,9 @@ endif
 ifndef DEF_TARGETS
 DEF_TARGETS := 1
 
+ifneq ($(MAKECMDGOALS),$$(TARGETS))
 $(MAKECMDGOALS): $$(TARGETS)
+endif
 $$(TARGETS):
 	$(Q)$$(MAKE) -C $$(_TOPDIR_) --no-print-directory $$(TARGETS)
 endif

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -101,6 +101,13 @@ $$(foreach RULE,$(ALL_RULES),$$(eval $$(RULE) := ))
 #
 $$(foreach ATTR,$(ALL_ATTRS),$$(eval $$(ATTR) := ))
 
+#
+# While we are here, define ease-of-use target for this directory
+#
+.PHONY: $$(PRODIR) $$(PRODIR)/
+$$(PRODIR) $$(PRODIR)/:
+	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,)
+
 include $(1)/Makefile
 endef
 
@@ -161,6 +168,11 @@ $$(TARGETS):
 endif
 
 else
+#
+# While we are here, define ease-of-use target for this product
+#
+$(PRODIR)\:$(2): $(if $(clean),clean.$(2),all.$(2))
+
 include $(Makefile.$(1))
 endif
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -78,6 +78,10 @@ Q := @
 endif
 
 
+#
+# Macro to clean the slate:
+# Undef all rules and their attributes + include toolchain for $$(ARCH)
+#
 define restore_defaults
 #
 # Set toolchain for the subdir and the ones below it. This can be overridden by
@@ -105,8 +109,7 @@ PRODIR := $(1)
 OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
 
 #
-# Clean the slate: undef all rules and their attributes +
-#                  include toolchain for $$(ARCH)
+# Start out fresh
 #
 $$(eval $$(call restore_defaults))
 
@@ -179,8 +182,7 @@ include $(Makefile.$(1))
 endif
 
 #
-# Clean the slate: undef all rules and their attributes +
-#                  include toolchain for $$(ARCH)
+# Reset for the next rule inclusion
 #
 $$(eval $$(call restore_defaults))
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -151,7 +151,7 @@ ifeq ($(TOPDIR),)
 #
 ifeq ($(MAKECMDGOALS),)
 TARGETS += all.$(2)
-else ifeq ($(filter all clean clean=,$(MAKECMDGOALS)),)
+else ifeq ($(filter all clean,$(MAKECMDGOALS)),)
 # Only "all|clean" goals are supported from all dir-levels. Any other goals are
 # simply run from TOPDIR w/o accumulation and conversion for actual targets
 TARGETS := $(MAKECMDGOALS)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -146,9 +146,7 @@ TARGETS += $(MAKECMDGOALS:%=%.$(2))
 endif
 
 #
-# o $$(TARGETS) needs to be defined only once.
-# o $$(TARGETS) is used in the definition since $$@
-#   expansion covers only the first target.
+# $$(TARGETS) needs to be defined only once.
 #
 ifndef DEF_TARGETS
 DEF_TARGETS := 1

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -280,3 +280,15 @@ clean_$$(METADATA_FILE_TMP):
 
 $(C_OBJS): $$(METADATA_FILE)
 endef
+
+
+#
+# Simple macro that implements BASH method to iteratively delete empty dirs
+#
+define del_empty_dirs
+	while true; do \
+		empty_dirs=$$(find $(1) -type d -empty 2>/dev/null); \
+		[ -z "$$empty_dirs" ] && break; \
+		rmdir $$empty_dirs; \
+	done;
+endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -158,7 +158,7 @@ TARGETS += $(MAKECMDGOALS:%=%.$(2))
 endif
 
 #
-# $$(TARGETS) needs to be defined only once.
+# Rule to execute $$(TARGETS) needs to be defined only once.
 #
 ifndef DEF_TARGETS
 DEF_TARGETS := 1

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -178,7 +178,7 @@ else
 #
 # While we are here, define ease-of-use target for this product
 #
-$(PRODIR)\:$(2): $(if $(clean),clean.$(2),all.$(2))
+$(PRODIR)\:$(2): $(if $(clean),clean,all).$(2)
 
 include $(Makefile.$(1))
 endif

--- a/build/Makefile.buildenv
+++ b/build/Makefile.buildenv
@@ -70,7 +70,7 @@ rmenv: stopenv
 #
 help.buildenv:
 	@echo "Build environment targets"
-	@echo "         env: Run a \"buildenv shell\" for this workspace"
-	@echo "       rmenv: Remove existing build-environment (must exit \"buildenv shell\" first)"
+	@echo "          env: Run a \"buildenv shell\" for this workspace"
+	@echo "        rmenv: Remove existing build-environment (must exit \"buildenv shell\" first)"
 
 .PHONY: mkenv stopenv

--- a/build/Makefile.cargo
+++ b/build/Makefile.cargo
@@ -31,6 +31,7 @@ $(BINELF): | $(PRODUCT_OBJDIR)
 	$(Q)$(CARGO) build --manifest-path $(PRODIR)/Cargo.toml --target-dir $(PRODUCT_OBJDIR) $(CARGO_TARGET_ARG) --jobs $(CORES) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(BINELF)
+	@true    # avoid "Nothing to be done for .."
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -48,7 +48,6 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" $(BINELF)
 	$(Q)rm -f $(BINELF) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
-	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)$(call del_empty_dirs,$(PRODUCT_OBJDIR))
 
 endif  # define C_BIN

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -41,9 +41,13 @@ $(BINELF): $(DEP_AR) $(C_OBJS)
 
 all.$(PRODUCT): $(BINELF)
 
+clean.$(PRODUCT):: BINELF := $(BINELF)
+clean.$(PRODUCT):: C_OBJS := $(C_OBJS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
-	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
-	$(Q)rm -rf $(PRODUCT_OBJDIR)
+	@printf "%$(PCOL)s %s\n" "[RM]" $(BINELF)
+	$(Q)rm -f $(BINELF) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
+	$(Q)rmdir $(dir $(C_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define C_BIN

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -48,6 +48,7 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" $(BINELF)
 	$(Q)rm -f $(BINELF) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)rmdir $(dir $(C_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
+	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define C_BIN

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -70,9 +70,16 @@ $(LIB_AR): $(DEP_AR) $(APIHDR) $(C_OBJS)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
+clean.$(PRODUCT):: LIB_SO := $(LIB_SO)
+clean.$(PRODUCT):: LIB_AR := $(LIB_AR)
+clean.$(PRODUCT):: APIHDR := $(APIHDR)
+clean.$(PRODUCT):: C_OBJS := $(C_OBJS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+clean.$(PRODUCT):: INC_PREFIX := $(PRODUCT_OBJDIR)/$(INC_PREFIX)
+clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
-	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
-	$(Q)rm -rf $(PRODUCT_OBJDIR)
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
+	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(APIHDR) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
+	$(Q)rmdir $(dir $(C_OBJS)) $(INC_PREFIX) $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define C_LIB

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -80,7 +80,6 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
 	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(APIHDR) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
-	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)$(call del_empty_dirs,$(PRODUCT_OBJDIR))
 
 endif  # define C_LIB

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -80,6 +80,7 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
 	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(APIHDR) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)rmdir $(dir $(C_OBJS)) $(INC_PREFIX) $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
+	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define C_LIB

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -54,9 +54,13 @@ $(LIB_AR): $(DEP_AR) $(PB_CC_OBJS)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
+clean.$(PRODUCT):: LIB_SO := $(LIB_SO)
+clean.$(PRODUCT):: LIB_AR := $(LIB_AR)
+clean.$(PRODUCT):: PB_CC_OBJS := $(PB_CC_OBJS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
-	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
-	$(Q)rm -rf $(PRODUCT_OBJDIR)
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
+	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(PB_CC_OBJS) $(PB_CC_OBJS:%.o=%.d) $(PB_CC_OBJS:%.o=%.cc) $(PB_CC_OBJS:%.o=%.h)
+	$(Q)rmdir $(dir $(PB_CC_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -62,7 +62,6 @@ clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
 	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(PB_CC_OBJS) $(PB_CC_OBJS:%.o=%.d) $(PB_CC_OBJS:%.o=%.cc) $(PB_CC_OBJS:%.o=%.h)
-	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
-	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)$(call del_empty_dirs,$(PRODUCT_OBJDIR))
 
 endif

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -61,6 +61,7 @@ clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(LIB_SO)|.a"
 	$(Q)rm -f $(LIB_SO) $(LIB_AR) $(PB_CC_OBJS) $(PB_CC_OBJS:%.o=%.d) $(PB_CC_OBJS:%.o=%.cc) $(PB_CC_OBJS:%.o=%.h)
-	$(Q)rmdir $(dir $(PB_CC_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
+	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -53,6 +53,7 @@ $(LIB_AR): $(DEP_AR) $(PB_CC_OBJS)
 	$(Q)$(AR) -c -r -s -o $@ $(filter-out $(CC_H_EXTS_PATT),$^)
 
 all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
+	@true    # avoid "Nothing to be done for .."
 
 clean.$(PRODUCT):: LIB_SO := $(LIB_SO)
 clean.$(PRODUCT):: LIB_AR := $(LIB_AR)

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -77,6 +77,7 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(ELF)|.bin|.hex|.map"
 	$(Q)rm -f $(ELF) $(BIN) $(HEX) $(LD_MAP) $(S_OBJS) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)rmdir $(dir $(C_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
+	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define STM32_ELF

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -77,7 +77,6 @@ clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(ELF)|.bin|.hex|.map"
 	$(Q)rm -f $(ELF) $(BIN) $(HEX) $(LD_MAP) $(S_OBJS) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
-	$(Q)find $(PRODUCT_OBJDIR) -type d -empty -exec rmdir {} \+ 2>/dev/null || true
-	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
+	$(Q)$(call del_empty_dirs,$(PRODUCT_OBJDIR))
 
 endif  # define STM32_ELF

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -66,9 +66,17 @@ $(HEX): $(ELF)
 
 all.$(PRODUCT): $(ELF) $(BIN) $(HEX)
 
+clean.$(PRODUCT):: ELF := $(ELF)
+clean.$(PRODUCT):: BIN := $(BIN)
+clean.$(PRODUCT):: HEX := $(HEX)
+clean.$(PRODUCT):: LD_MAP := $(LD_MAP)
+clean.$(PRODUCT):: C_OBJS := $(C_OBJS)
+clean.$(PRODUCT):: S_OBJS := $(S_OBJS)
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
+clean.$(PRODUCT):: METADATA_FILE := $(METADATA_FILE)
 clean.$(PRODUCT):
-	@printf "%$(PCOL)s %s\n" "[RM]" $(PRODUCT_OBJDIR)
-	$(Q)rm -rf $(PRODUCT_OBJDIR)
+	@printf "%$(PCOL)s %s\n" "[RM]" "$(ELF)|.bin|.hex|.map"
+	$(Q)rm -f $(ELF) $(BIN) $(HEX) $(LD_MAP) $(S_OBJS) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
+	$(Q)rmdir $(dir $(C_OBJS)) $(PRODUCT_OBJDIR) 2>/dev/null || true
 
 endif  # define STM32_ELF

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -38,6 +38,7 @@ $(ELF): $(ZEPHYR_APP_DEP_FILES) | $(BOARD_PRODUCT_OBJDIR)
 	$(Q)ZEPHYR_BASE=$(ZEPHYR_HOME)/zephyr $(ZEPHYR_TOOLCHAIN_ARGS) $(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)
+	@true    # avoid "Nothing to be done for .."
 
 clean.$(PRODUCT):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 clean.$(PRODUCT):: BOARD_PRODUCT_OBJDIR := $(BOARD_PRODUCT_OBJDIR)


### PR DESCRIPTION
- build: fine tuned all|clean targets for C_LIB and C_BIN

These are simple yet fine-tuned targets to build source in individual directories or individual products defined in a Makefile. For example,

```
# following builds all source under the said directory recursively
make cmds/common/pb_example
```
```  
# following builds only the "add_person" product in the
# Makefile of the said directory (but won't build "list_people" etc.)
make cmds/common/pb_example:add_person
```

Likewise, "clean=1" can be specified to clean the product instead. For examples above,
```
# following would remove objects built
make cmds/common/pb_example clean=1
make cmds/common/pb_example:add_person clean=1
```
These aren't advertised in "make help".

Testing done
```
# clean slate
$ make cleanall
      [RM] objs.*

# use a directory with a makefile with multiple products
# demo building all targets within the directory recursively
$ make cmds/common/pb_example/
  [PROTOC] objs.x86_64/cmds/common/pb_example/proto/addressbook.pb.cc
     [CXX] objs.x86_64/cmds/common/pb_example/proto/addressbook.pb.o
      [AR] objs.x86_64/cmds/common/pb_example/proto/libaddressbook.a
     [CXX] objs.x86_64/cmds/common/pb_example/src/add_person.o
   [CXXLD] objs.x86_64/cmds/common/pb_example/add_person
     [CXX] objs.x86_64/cmds/common/pb_example/src/list_people.o
   [CXXLD] objs.x86_64/cmds/common/pb_example/list_people
   [CXXLD] objs.x86_64/cmds/common/pb_example/proto/libaddressbook.so

# all built objects
$ ls objs.x86_64/cmds/common/pb_example/
add_person  list_people  metadata.add_person.mk  metadata.list_people.mk  proto  src

# demo cleaning only "add_person" product
$ make cmds/common/pb_example:add_person clean=1
      [RM] objs.x86_64/cmds/common/pb_example/add_person

# remaining built objects (note that "add_person" objects are deleted)
$ ls objs.x86_64/cmds/common/pb_example/
list_people  metadata.list_people.mk  proto  src

# clean "list_people" product
$ make cmds/common/pb_example:list_people clean=1
      [RM] objs.x86_64/cmds/common/pb_example/list_people

# remaining objects
$ ls objs.x86_64/cmds/common/pb_example/
proto

# clean final product in the makefile
$ make cmds/common/pb_example/proto/ clean=1
      [RM] objs.x86_64/cmds/common/pb_example/proto

# all built objects have been deleted
$ ls objs.x86_64/cmds/common/pb_example/
<empty>
```