### PR TITLE
build: added "flash" target to program a f/w binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,9 +84,11 @@ help:
 	@echo "<path>[:prod]: build all $(ARCH) products for <path> and subdirs below"
 	@echo "               if specified, build only the product "prod" in the <path>"
 	@echo "               Specify \"clean=1\" to clean"
+	@echo "               Specify \"flash=1\" to program f/w binary (when applicable)"
 	@echo "               For example, make libs/common"
 	@echo "                            make cmds/common/pb_example:list_people"
 	@echo "                            make libs/common clean=1"
+	@echo "                            make firmware/zephyr/hello_world:hello_world.nucleo_f401re flash=1"
 	@echo
 	@$(MAKE) --no-print-directory help.buildenv
 	@echo
@@ -95,6 +97,8 @@ help:
 	@echo "               Supported: $(SUPPORTED_ARCHS) [Default: $(TARGET_ARCH)]"
 	@echo "      VERBOSE: build verbosity"
 	@echo "               On/Off if defined/undefined [Default: not defined]"
+	@echo "   DEV_SERIAL: s/n# of a st-link programmer (from \"st-info --probe\")"
+	@echo "               Useful when multiple boards are connected [Default: none]"
 	@echo
 	@echo "Other supported build systems (outside of default build system)"
 	@echo "          ROS: make help.ros"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -310,5 +310,5 @@ $(1): $(2)
 	$(Q)if [ -z "$$(reset_only)" ]; then \
 		$$(ST_FLASH) erase && $$(ST_FLASH) write $(3) 0x8000000; \
 	fi && \
-	echo "$$(ST_FLASH) reset"
+	$$(ST_FLASH) reset
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -40,7 +40,7 @@ CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
 PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
 PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
 # Number of colums to print at start of line in build output
-PCOL := 10
+PCOL := 12
 
 #
 # All supported rules
@@ -174,9 +174,11 @@ endif
 
 else
 #
-# While we are here, define ease-of-use target for this product
+# While we are here, define ease-of-use target for this product.
+# "flash" target is applicable only to specific products and hence
+# defined only here
 #
-$(PRODIR)\:$(2): $(if $(clean),clean,all).$(2)
+$(PRODIR)\:$(2): $(if $(clean),clean,$(if $(flash),flash,all)).$(2)
 
 include $(Makefile.$(1))
 endif
@@ -291,4 +293,20 @@ define del_empty_dirs
 		[ -z "$$empty_dirs" ] && break; \
 		rmdir $$empty_dirs 2>/dev/null || true; \
 	done;
+endef
+
+
+#
+# Common macro to add "flash" target for STM32_ELF and ZEPHYR_APP
+# It currently assumes the ST-Micro boards and hence uses st-flash
+# [in] - target name, target dependency, path-to-fw-binary
+#
+define add_flash_tgt
+$(1):: SUDO := $(if $(filter Linux,$(shell uname)),sudo,)
+$(1):: DEV_SR := $(if $(DEV_SERIAL),--serial $(DEV_SERIAL),)
+$(1): $(2)
+	@printf "%$(PCOL)s %s\n" "[ST-FLASH]" "$(3)"
+	$(Q)$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset erase && \
+	$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset write $(3) 0x8000000 && \
+	$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset reset
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -304,9 +304,11 @@ endef
 define add_flash_tgt
 $(1):: SUDO := $(if $(filter Linux,$(shell uname)),sudo,)
 $(1):: DEV_SR := $(if $(DEV_SERIAL),--serial $(DEV_SERIAL),)
+$(1):: ST_FLASH := $$(SUDO) st-flash $$(DEV_SR) --connect-under-reset
 $(1): $(2)
 	@printf "%$(PCOL)s %s\n" "[ST-FLASH]" "$(3)"
-	$(Q)$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset erase && \
-	$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset write $(3) 0x8000000 && \
-	$$(SUDO) st-flash $$(DEV_SR) --connect-under-reset reset
+	$(Q)if [ -z "$$(reset_only)" ]; then \
+		$$(ST_FLASH) erase && $$(ST_FLASH) write $(3) 0x8000000; \
+	fi && \
+	echo "$$(ST_FLASH) reset"
 endef

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -148,6 +148,7 @@ RUN apt-get update && \
 
 # Global buildenv wide settings
 ENV VER=
+ENV ZEPHYR_BASE=$ZEPHYR_HOME/zephyr
 ENV PATH=$CARGO_HOME/bin:$PATH
 
 # Add "this" user to buildenv image

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -79,4 +79,7 @@ clean.$(PRODUCT):
 	$(Q)rm -f $(ELF) $(BIN) $(HEX) $(LD_MAP) $(S_OBJS) $(C_OBJS) $(C_OBJS:%.o=%.d) $(METADATA_FILE)
 	$(Q)$(call del_empty_dirs,$(PRODUCT_OBJDIR))
 
+# Add ease-of-use "flash" target to program the product on a [ST-Micro] board
+$(eval $(call add_flash_tgt,flash.$(PRODUCT),$(BIN),$(BIN)))
+
 endif  # define STM32_ELF

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -35,7 +35,7 @@ $(ELF):: ZEPHYR_TOOLCHAIN_ARGS := $(ZEPHYR_TOOLCHAIN_ARGS)
 $(ELF): $(ZEPHYR_APP_DEP_FILES) | $(BOARD_PRODUCT_OBJDIR)
 	@printf "%$(PCOL)s %s\n" "[WEST]" $@ && \
 		printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
-	$(Q)ZEPHYR_BASE=$(ZEPHYR_HOME)/zephyr $(ZEPHYR_TOOLCHAIN_ARGS) $(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
+	$(Q)$(ZEPHYR_TOOLCHAIN_ARGS) $(WEST) build $(PRODIR) -b $(BOARD) --build-dir $(realpath $(BOARD_PRODUCT_OBJDIR)) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(ELF)
 	@true    # avoid "Nothing to be done for .."

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -47,4 +47,7 @@ clean.$(PRODUCT):
 	$(Q)rm -rf $(BOARD_PRODUCT_OBJDIR)
 	$(Q)rmdir $(PRODUCT_OBJDIR) 2>/dev/null || true
 
+# Add ease-of-use "flash" target to program the product on a [ST-Micro] board
+$(eval $(call add_flash_tgt,flash.$(PRODUCT),$(ELF),$(ELF:%.elf=%.bin)))
+
 endif  # ifdef ZEPHYR_APP


### PR DESCRIPTION
Yet another ease of use target. It supports only st-link programmers and hence uses `st-flash` utility (with write address at `0x08000000`). The target essentially is a shortcut to `st-flash` command(s) needed to program a f/w binary to a board.

Tested with multiple board conceded to host/build machine (Mac)
```
# build
$ make firmware/zephyr/hello_world:hello_world.nucleo_f401re
      [WEST] objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.elf
             Logs: objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/build.log
$ make firmware/zephyr/echo:echo.nucleo_f767zi
      [WEST] objs.firmware/firmware/zephyr/echo/nucleo_f767zi/zephyr/zephyr.elf
             Logs: objs.firmware/firmware/zephyr/echo/nucleo_f767zi/build.log

# flash nucleo_f401re board
$ make firmware/zephyr/hello_world:hello_world.nucleo_f401re flash=1 DEV_SERIAL=0664FF515250898367123850
  [ST-FLASH] objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.bin
st-flash 1.6.1-306-geeaef98
2021-05-19T23:13:38 INFO common.c: F4xx (Dynamic Efficency): 96 KiB SRAM, 512 KiB flash in at least 16 KiB pages.
Mass erasing......
st-flash 1.6.1-306-geeaef98
2021-05-19T23:13:45 INFO common.c: F4xx (Dynamic Efficency): 96 KiB SRAM, 512 KiB flash in at least 16 KiB pages.
file objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.bin md5 checksum: 5182ef52cc2aabc5c6255783e66acb9f, stlink checksum: 0x0013c11e
2021-05-19T23:13:45 INFO common.c: Attempting to write 13832 (0x3608) bytes to stm32 address: 134217728 (0x8000000)
EraseFlash - Sector:0x0 Size:0x4000 2021-05-19T23:13:45 INFO common.c: Flash page at addr: 0x08000000 erased
2021-05-19T23:13:45 INFO common.c: Finished erasing 1 pages of 16384 (0x4000) bytes
2021-05-19T23:13:45 INFO common.c: Starting Flash write for F2/F4/F7/L4
2021-05-19T23:13:45 INFO flash_loader.c: Successfully loaded flash loader in sram
2021-05-19T23:13:45 INFO flash_loader.c: Clear DFSR
2021-05-19T23:13:45 INFO common.c: enabling 32-bit flash writes
2021-05-19T23:13:46 INFO common.c: Starting verification of write complete
2021-05-19T23:13:46 INFO common.c: Flash written and verified! jolly good!
st-flash 1.6.1-306-geeaef98
2021-05-19T23:13:46 INFO common.c: F4xx (Dynamic Efficency): 96 KiB SRAM, 512 KiB flash in at least 16 KiB pages.

# flash nucleo_f767zi board
$ make firmware/zephyr/echo:echo.nucleo_f767zi flash=1 DEV_SERIAL=066BFF555052836687093420
[ST-FLASH] objs.firmware/firmware/zephyr/echo/nucleo_f767zi/zephyr/zephyr.bin
st-flash 1.6.1-306-geeaef98
2021-05-19T23:12:55 INFO common.c: F76xxx: 512 KiB SRAM, 2048 KiB flash in at least 2 KiB pages.
Mass erasing..............
st-flash 1.6.1-306-geeaef98
2021-05-19T23:13:10 INFO common.c: F76xxx: 512 KiB SRAM, 2048 KiB flash in at least 2 KiB pages.
file objs.firmware/firmware/zephyr/echo/nucleo_f767zi/zephyr/zephyr.bin md5 checksum: 8134d4ac476e8028a844d1f6efd14f2b, stlink checksum: 0x008b2424
2021-05-19T23:13:10 INFO common.c: Attempting to write 90484 (0x16174) bytes to stm32 address: 134217728 (0x8000000)
EraseFlash - Sector:0x0 Size:0x8000 2021-05-19T23:13:11 INFO common.c: Flash page at addr: 0x08000000 erased
EraseFlash - Sector:0x1 Size:0x8000 2021-05-19T23:13:11 INFO common.c: Flash page at addr: 0x08008000 erased
EraseFlash - Sector:0x2 Size:0x8000 2021-05-19T23:13:11 INFO common.c: Flash page at addr: 0x08010000 erased
2021-05-19T23:13:11 INFO common.c: Finished erasing 3 pages of 32768 (0x8000) bytes
2021-05-19T23:13:11 INFO common.c: Starting Flash write for F2/F4/F7/L4
2021-05-19T23:13:11 INFO flash_loader.c: Successfully loaded flash loader in sram
2021-05-19T23:13:11 INFO flash_loader.c: Clear DFSR
2021-05-19T23:13:11 INFO common.c: enabling 32-bit flash writes
2021-05-19T23:13:13 INFO common.c: Starting verification of write complete
2021-05-19T23:13:13 INFO common.c: Flash written and verified! jolly good!
st-flash 1.6.1-306-geeaef98
2021-05-19T23:13:13 INFO common.c: F76xxx: 512 KiB SRAM, 2048 KiB flash in at least 2 KiB pages.
```
When `flash=1` is used at misplaced places, the target fails with error (due to lack of thereof):
```
$ make libs/common/hello:hello flash=1
make: *** No rule to make target 'flash.hello', needed by 'libs/common/hello:hello'.  Stop.
```