### PR TITLE
build: allow same name for multiple products in different paths

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -246,9 +246,9 @@ endef
 #         Dependency LFLAGS: $(DEP_LD)
 #
 define eval_clib_deps
-DEPDIR := $$(foreach dep,$$(DEPEND),$$(firstword $$(subst :, ,$$(dep))))
+DEPDIR := $$(foreach dep,$$(DEPEND),$$(firstword $$(subst :, ,$$(dep)))) $$(PRODIR)
 DEPTGT := $$(foreach dep,$$(DEPEND),$$(lastword $$(subst :, ,$$(dep))))
-DEP_SO := $$(foreach dep,$$(DEPEND),$$(patsubst %,$$(OBJDIR)/%.so,$$(subst :,/lib,$$(dep))))
+DEP_SO := $$(foreach dep,$$(DEPEND),$$(patsubst %,$$(OBJDIR)/%.so,$$(if $$(firstword $$(patsubst :%,,$$(dep))),,$$(PRODIR))$$(subst :,/lib,$$(dep))))
 DEP_AR := $$(DEP_SO:%.so=%.a)
 DEPINC := $$(DEPDIR:%=-I$$(OBJDIR)/%)
 DEP_LD := $$(DEPDIR:%=-L$$(OBJDIR)/%)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -267,7 +267,7 @@ define cflags_change_tgt
 # List of flags to detect change in
 DIFF_FLAGS := CFLAGS LFLAGS CXXFLAGS
 
-METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.$(1).mk
+METADATA_FILE := $(PRODUCT_OBJDIR)/metadata.$(1)__$(2).mk
 METADATA_FILE_TMP := $$(METADATA_FILE:%=%.tmp)
 
 $$(METADATA_FILE):: CFLAGS := $(CFLAGS)
@@ -277,7 +277,7 @@ $$(METADATA_FILE):: METADATA_FILE_TMP := $$(METADATA_FILE_TMP)
 $$(METADATA_FILE): clean_$$(METADATA_FILE_TMP) | $(PRODUCT_OBJDIR)
 	$$(foreach flag,$$(DIFF_FLAGS),$$(shell eval "echo $$(flag) := $$($$(flag)) >> $$(METADATA_FILE_TMP)"))
 	@if [ ! -f $$@ ] || ! diff $$@ $$(METADATA_FILE_TMP) >/dev/null; then \
-		[ -f $$@ ] && printf "%$(PCOL)s %s\n" "[=>]" "$$(@D)/$(1) [flags changed]"; \
+		[ -f $$@ ] && printf "%$(PCOL)s %s\n" "[=>]" "$$(@D)/$(2) [flags changed]"; \
 		mv $$(METADATA_FILE_TMP) $$@; \
 	else \
 		rm $$(METADATA_FILE_TMP); \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -105,25 +105,26 @@ endef
 # Macro to include a sub-directory
 #
 define subdirs
-PRODIR := $(1)
-OBJDIR := $(OBJDIR_PREFIX)$(ARCH)
-
 #
-# Start out fresh
-#
-$$(eval $$(call restore_defaults))
-
-#
-# While we are here, define ease-of-use target for this subdir
-# but only when invoked from TOPDIR to define targets for
-# subdir paths relative to TOPDIR only
+# While including this subdir also define ease-of-use target for it
+# but only when invoked from TOPDIR to define a target for subdir's
+# path relative to TOPDIR only
 #
 ifneq ($(TOPDIR),)
+PRODIR := $(1)
 DIR_TGT := $$(PRODIR) $$(PRODIR)/
 .PHONY: $$(DIR_TGT)
 $$(DIR_TGT):
 	$(Q)$$(MAKE) --no-print-directory -C $$@ $$(if $$(clean),clean,all)
+
+else
+PRODIR := $(shell realpath . --relative-to $(_TOPDIR_))/$(subst ./,,$(1))
 endif
+
+#
+# Reset state before including this subdir
+#
+$$(eval $$(call restore_defaults))
 
 include $(1)/Makefile
 endef
@@ -141,20 +142,26 @@ endef
 # Wrapper macro to include "Makefile.<rule>".
 #
 define inc_rule
-ifeq ($(TOPDIR),)
+# When inc_rule() called from bottom level subdir
+PRODIR ?= $(shell realpath . --relative-to $(_TOPDIR_))
+# Prepend path and rule type to the product name to make it unique in that path
+PRODUCT := $$(PRODIR)__$(1)__$(2)
+# For top Makefile
+PRODUCTS += $$(PRODUCT)
 
+ifeq ($(TOPDIR),)
 #
 # inc_rule() may be called more than once in a Makefile and each
 # time, we accumulate goals to be built by updating TARGETS
 #
 ifeq ($(MAKECMDGOALS),)
-TARGETS += all.$(2)
+$$(eval TARGETS += all.$$(PRODUCT))
 else ifeq ($(filter all clean,$(MAKECMDGOALS)),)
 # Only "all|clean" goals are supported from all dir-levels. Any other goals are
 # simply run from TOPDIR w/o accumulation and conversion for actual targets
 TARGETS := $(MAKECMDGOALS)
 else
-TARGETS += $(MAKECMDGOALS:%=%.$(2))
+$$(eval TARGETS += $$(MAKECMDGOALS:%=%.$$(PRODUCT)))
 endif
 
 #
@@ -178,7 +185,7 @@ else
 # "flash" target is applicable only to specific products and hence
 # defined only here
 #
-$(PRODIR)\:$(2): $(if $(clean),clean,$(if $(flash),flash,all)).$(2)
+$(PRODIR)\:$(2): $$(if $$(clean),clean,$$(if $$(flash),flash,all)).$$(PRODUCT)
 
 include $(Makefile.$(1))
 endif

--- a/build/Makefile.cargo
+++ b/build/Makefile.cargo
@@ -1,9 +1,7 @@
 ifdef CARGO_PROJ
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(CARGO_PROJ)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
+
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 
 # For top Makefile

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -24,7 +24,7 @@ LFLAGS += $(DEP_LD)
 CXXFLAGS += --std=c++17
 
 # Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,$(C_BIN)))
+$(eval $(call cflags_change_tgt,cbin,$(C_BIN)))
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -1,9 +1,6 @@
 ifdef C_BIN
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(C_BIN)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -1,9 +1,6 @@
 ifdef C_LIB
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(C_LIB)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -27,7 +27,7 @@ LFLAGS += $(DEP_LD)
 CXXFLAGS += --std=c++17
 
 # Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,$(C_LIB)))
+$(eval $(call cflags_change_tgt,clib,$(C_LIB)))
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -1,9 +1,6 @@
 ifdef PROTO_LIB
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(PROTO_LIB)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -31,7 +31,7 @@ LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
 LFLAGS += $(DEP_LD)
 
 # Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,$(STM32_ELF)))
+$(eval $(call cflags_change_tgt,stm32,$(STM32_ELF)))
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -4,9 +4,7 @@ ifdef STM32_ELF
 $(eval $(call inc_toolchain,firmware))
 
 # This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(STM32_ELF)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
+
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
 
 ELF := $(PRODUCT_OBJDIR)/$(STM32_ELF).elf

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -3,19 +3,17 @@ ifdef ZEPHYR_APP
 # Override to use appropriate $(OBJDIR) location (toolchain is already selected by buildenv)
 $(eval $(call inc_toolchain,firmware))
 
+# This file defines rules for targets: [all|clean].$(PRODUCT)
+
+PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
+BOARD_PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)/$(BOARD)
+
 # Use arm-none-eabi- toolchain to build firmware unless explictly specified
 # in product makefile as one or more space sparated BASH key=val
 ifeq ($(ZEPHYR_TOOLCHAIN_ARGS),)
 ZEPHYR_TOOLCHAIN_ARGS := ZEPHYR_TOOLCHAIN_VARIANT=cross-compile
 ZEPHYR_TOOLCHAIN_ARGS += CROSS_COMPILE=/usr/bin/arm-none-eabi-
 endif
-
-# This file defines rules for targets: [all|clean].$(PRODUCT)
-PRODUCT := $(ZEPHYR_APP)
-# For top Makefile
-PRODUCTS += $(PRODUCT)
-PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
-BOARD_PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)/$(BOARD)
 
 # For top Makefile
 OBJ_SUBDIRS += $(BOARD_PRODUCT_OBJDIR)


### PR DESCRIPTION
Same name is also allowed in a path for products for different rule.
For example, C_LIB=C_BIN=hello is allowed for a <PATH> but multiple
C_BIN=hello is not.

This commit also adds "realpath" as dependency in buildenv which might
be an irritant when calling "buildenv targets" such as "make env" if
it's not present in the host's environment.

Tested by ensuring that build succeeds when `libs/common/hello:hello` and `libs/common/hello_cpp:hello` (i.e C_LIB=hello in different paths).
Also, added a temporary C_BIN in `libs/common/hello:hello` (same as C_LIB `libs/common/hello:hello`) and verified that it builds and cleans as expected:
```
$ make libs/common/hello:hello
        [CC] objs.x86_64/libs/common/hello/src/hello.o
     [CXXLD] objs.x86_64/libs/common/hello/libhello.so
        [AR] objs.x86_64/libs/common/hello/libhello.a
        [CC] objs.x86_64/libs/common/hello/src/hello_world.o
     [CXXLD] objs.x86_64/libs/common/hello/hello
$ tree objs.x86_64/
objs.x86_64/
`-- libs
    `-- common
        `-- hello
            |-- hello
            |-- libhello
            |   `-- hello.h -> /home/popbot/tejas/stm-main/libs/common/hello/inc/hello.h
            |-- libhello.a
            |-- libhello.so
            |-- metadata.cbin__hello.mk
            |-- metadata.clib__hello.mk
            `-- src
                |-- hello.d
                |-- hello.o
                |-- hello_world.d
                `-- hello_world.o

5 directories, 10 files
$ make libs/common/hello:hello clean=1
        [RM] objs.x86_64/libs/common/hello/libhello.so|.a
        [RM] objs.x86_64/libs/common/hello/hello
```

Also, verified that directory targets works as expected. Some examples:
```
$ make libs/common 
$ make firmware/nucleo/Lidar_Delivery/
$ make cmds/common/pb_example:add_person
```

**NOTE**: When multiple products for a rule have the same target name in the same Makefile (i.e. in a directory path), `make` will override previous recipe and dump bunch of warnings without failing. So that's uncool but will provide hint to rectify the issue.

This feature implementation will likely need some revision.