### PR TITLE
build: added support to lint C/C++ source using clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,53 @@
+Checks: 'cppcoreguidelines-*,
+performance-*,
+modernize-*,
+google-*,
+misc-*
+cert-*,
+readability-*,
+clang-analyzer-*,
+-performance-unnecessary-value-param,
+-modernize-use-trailing-return-type,
+-google-runtime-references,
+-misc-non-private-member-variables-in-classes,
+-readability-braces-around-statements,
+-google-readability-braces-around-statements,
+-cppcoreguidelines-avoid-magic-numbers,
+-readability-magic-numbers,
+-readability-magic-numbers,
+-cppcoreguidelines-pro-type-vararg,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-avoid-c-arrays,
+-modernize-avoid-c-arrays,
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+-readability-named-parameter,
+-cert-env33-c
+'
+
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '*spdlog/[^f].*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+
+CheckOptions:
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,8 +25,7 @@ clang-analyzer-*,
 '
 
 
-WarningsAsErrors: ''
-HeaderFilterRegex: '*spdlog/[^f].*'
+WarningsAsErrors: '*'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -237,7 +237,7 @@ $$(OBJFILE):: CLANG_TIDY_DEP := $$(CLANG_TIDY_DEP)
 $$(OBJFILE): $(1) $$(CLANG_TIDY_DEP) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
 	$(Q)if [ -n "$$(CLANG_TIDY_DEP)" ]; then \
-		clang-tidy -quiet $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
+		clang-tidy -quiet -warnings-as-errors="*" $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
 	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -219,17 +219,22 @@ else
 $$(error ERROR: Invalid C/C++ suffix '$(1)' (Supported: .c $$(CC_EXTS)))
 endif
 
+# Flag to distinguish a source file from a generated one (from protoc).
+# This is used to avoid running clang-tidy on generated files
+GENERATED := $(if $(filter $(OBJDIR),$(subst /, ,$(1))),1,0)
+
 # Remove $(OBJDIR) prefix from "SRCFILE" (aka $(1)) [in case if it's a generated one]
 # before adding it as a prefix to "OBJFILE"
 OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(subst $(OBJDIR)/,,$(1)))
 
+$$(OBJFILE):: GENERATED := $$(GENERATED)
 $$(OBJFILE):: GCCSTR := $$(GCCSTR)
 $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
-	$(Q)clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_FLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS)
+	$(Q)[ "$$(GENERATED)" = "0" ] && clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_FLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS)
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -237,7 +237,7 @@ $$(OBJFILE):: CLANG_TIDY_DEP := $$(CLANG_TIDY_DEP)
 $$(OBJFILE): $(1) $$(CLANG_TIDY_DEP) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
 	$(Q)if [ -n "$$(CLANG_TIDY_DEP)" ]; then \
-		clang-tidy -quiet -warnings-as-errors="*" $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
+		clang-tidy -quiet $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
 	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -23,6 +23,7 @@ Makefile.ros := $(_TOPDIR_)/build/Makefile.ros
 Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
 Makefile.zephyr := $(_TOPDIR_)/build/Makefile.zephyr
+CLANG_TIDY_CONFIG := $(_TOPDIR_)/.clang-tidy
 
 #
 # Common constants
@@ -222,6 +223,7 @@ endif
 # Flag to distinguish a source file from a generated one (from protoc).
 # This is used to avoid running clang-tidy on generated files
 GENERATED := $(if $(filter $(OBJDIR),$(subst /, ,$(1))),1,0)
+CLANG_TIDY_DEP := $$(shell [ "$$(GENERATED)" = "0" ] && [ -z "$$(NO_LINT)" ] && echo $$(CLANG_TIDY_CONFIG))
 
 # Remove $(OBJDIR) prefix from "SRCFILE" (aka $(1)) [in case if it's a generated one]
 # before adding it as a prefix to "OBJFILE"
@@ -231,11 +233,10 @@ $$(OBJFILE):: GCCSTR := $$(GCCSTR)
 $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
-$$(OBJFILE):: GENERATED := $$(GENERATED)
-$$(OBJFILE):: NO_LINT := $$(NO_LINT)
-$$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
+$$(OBJFILE):: CLANG_TIDY_DEP := $$(CLANG_TIDY_DEP)
+$$(OBJFILE): $(1) $$(CLANG_TIDY_DEP) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
-	$(Q)if [ "$$(GENERATED)" = "0" ] && [ -z "$$(NO_LINT)" ]; then \
+	$(Q)if [ -n "$$(CLANG_TIDY_DEP)" ]; then \
 		clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
 	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -54,7 +54,7 @@ ALL_RULES := STM32_ELF C_LIB C_BIN PROTO_LIB ZEPHYR_APP CARGO_PROJ
 # of Makefile.<rule> for proper init state for the new "PRODUCT"
 #
 COMMON_ATTRS := PRODUCT
-COMMON_C_ATTRS := CFLAGS CXXFLAGS LFLAGS H_DIRS C_SRCS DEPEND
+COMMON_C_ATTRS := CFLAGS CXXFLAGS LFLAGS H_DIRS C_SRCS DEPEND NO_LINT
 STM32_ELF_ATTRS := S_SRCS LD_SRC $(COMMON_C_ATTRS)
 C_LIB_ATTRS := I_HDRS STRIP_INC_PREFIX INC_PREFIX $(COMMON_C_ATTRS)
 C_BIN_ATTRS := $(COMMON_C_ATTRS)
@@ -227,14 +227,15 @@ GENERATED := $(if $(filter $(OBJDIR),$(subst /, ,$(1))),1,0)
 # before adding it as a prefix to "OBJFILE"
 OBJFILE := $(OBJDIR)/$$(patsubst %$$(SUFFIX),%.o,$(subst $(OBJDIR)/,,$(1)))
 
-$$(OBJFILE):: GENERATED := $$(GENERATED)
 $$(OBJFILE):: GCCSTR := $$(GCCSTR)
 $$(OBJFILE):: GCC := $$(GCC)
 $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
+$$(OBJFILE):: GENERATED := $$(GENERATED)
+$$(OBJFILE):: NO_LINT := $$(NO_LINT)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
-	$(Q)if [ "$$(GENERATED)" = "0" ]; then \
+	$(Q)if [ "$$(GENERATED)" = "0" ] && [ -z "$$(NO_LINT)" ]; then \
 		clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
 	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -41,6 +41,8 @@ PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
 PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
 # Number of colums to print at start of line in build output
 PCOL := 12
+# For clang-tidy. Enumerate flags that clang doesn't support to filter them out
+CLANG_UNSUPPORTED_FLAGS := -mcpu=cortex-m4 -mthumb-interwork
 
 #
 # All supported rules
@@ -227,6 +229,7 @@ $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
+	$(Q)clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_FLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS)
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -237,7 +237,7 @@ $$(OBJFILE):: CLANG_TIDY_DEP := $$(CLANG_TIDY_DEP)
 $$(OBJFILE): $(1) $$(CLANG_TIDY_DEP) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
 	$(Q)if [ -n "$$(CLANG_TIDY_DEP)" ]; then \
-		clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
+		clang-tidy -quiet $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
 	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -42,7 +42,7 @@ PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread
 # Number of colums to print at start of line in build output
 PCOL := 12
 # For clang-tidy. Enumerate flags that clang doesn't support to filter them out
-CLANG_UNSUPPORTED_FLAGS := -mcpu=cortex-m4 -mthumb-interwork
+CLANG_UNSUPPORTED_CFLAGS := -mcpu=cortex-m4 -mthumb-interwork
 
 #
 # All supported rules
@@ -234,7 +234,9 @@ $$(OBJFILE):: CFLAGS := $$(CFLAGS)
 $$(OBJFILE):: CXXFLAGS := $$(CXXFLAGS)
 $$(OBJFILE): $(1) | $$(dir $$(OBJFILE))
 	@printf "%$(PCOL)s %s\n" $$(GCCSTR) $$@
-	$(Q)[ "$$(GENERATED)" = "0" ] && clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_FLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS)
+	$(Q)if [ "$$(GENERATED)" = "0" ]; then \
+		clang-tidy $$< -- $$(filter-out $$(CLANG_UNSUPPORTED_CFLAGS),$$(CFLAGS)) $$(CXXFLAGS) $$(DEPFLAGS); \
+	fi
 	$(Q)$$(GCC) $$(CFLAGS) $$(CXXFLAGS) $$(DEPFLAGS) -c $$< -o $$@
 	@mv -f $$*.Td $$*.d && touch $$@
 

--- a/cmds/common/hello_world_cpp/src/hello_world.cpp
+++ b/cmds/common/hello_world_cpp/src/hello_world.cpp
@@ -1,6 +1,6 @@
 #include "libhello_cpp/hello.hpp"
 
-int main(void) {
+int main() {
   common::Hello hello("Tejas");
   hello.printMsg("Hello CPP World!");
   return 0;

--- a/cmds/common/pb_example/Makefile
+++ b/cmds/common/pb_example/Makefile
@@ -13,6 +13,9 @@ DEPEND := cmds/common/pb_example/proto:addressbook
 CFLAGS += $(PROTOBUF_CFLAGS)
 LFLAGS += $(PROTOBUF_LFLAGS)
 
+# Imported from internet: skip linting add_person.cc
+NO_LINT := 1
+
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,cbin,$(C_BIN)))
 
@@ -23,6 +26,9 @@ C_SRCS := src/list_people.cc
 DEPEND := cmds/common/pb_example/proto:addressbook
 CFLAGS += $(PROTOBUF_CFLAGS)
 LFLAGS += $(PROTOBUF_LFLAGS)
+
+# Imported from internet: skip linting list_people.cc
+NO_LINT := 1
 $(eval $(call inc_rule,cbin,$(C_BIN)))
 
 # add proto_lib

--- a/firmware/libs/FreeRTOS/Makefile
+++ b/firmware/libs/FreeRTOS/Makefile
@@ -23,6 +23,9 @@ INC_PREFIX :=
 CFLAGS += $(STM32_CFLAGS)
 CFLAGS += -mthumb-interwork -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -std=gnu90 -ffunction-sections -fdata-sections
 
+# Imported from internet: skip linting FreeRTOS
+NO_LINT := 1
+
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 
 # Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location

--- a/firmware/nucleo/Lidar_Delivery/Makefile
+++ b/firmware/nucleo/Lidar_Delivery/Makefile
@@ -6,5 +6,8 @@ C_SRCS := $(shell find $(THIS_DIR) -name "*.c" -printf "%P\n" 2>/dev/null | sed 
 S_SRCS := $(shell find $(THIS_DIR) -name "*.s" -printf "%P\n" 2>/dev/null | sed "s|^\./||")
 LD_SRC := LinkerScript.ld
 
+# Imported from internet: skip linting Lidar_Delivery
+NO_LINT := 1
+
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_rule,stm32,$(STM32_ELF)))

--- a/libs/common/hello_cpp/inc/hello.hpp
+++ b/libs/common/hello_cpp/inc/hello.hpp
@@ -6,7 +6,7 @@ namespace common {
 
 class Hello {
  public:
-  explicit Hello(const std::string& user = "Guest");
+  explicit Hello(std::string user = "Guest");
   void printMsg(const std::string& msg);
 
  private:

--- a/libs/common/hello_cpp/src/hello.cpp
+++ b/libs/common/hello_cpp/src/hello.cpp
@@ -5,7 +5,7 @@
 
 namespace common {
 
-Hello::Hello(const std::string& user) : user_(user) {}
+Hello::Hello(std::string user) : user_(std::move(user)) {}
 
 void Hello::printMsg(const std::string& msg) { std::cout << msg << " " << user_ << std::endl; }
 


### PR DESCRIPTION
Basic linting support using `clang-tidy`. The "config" file - `.clang-tidy` - is borrowed from internet ([spdlog](https://github.com/gabime/spdlog/blob/v1.x/.clang-tidy)) and needs massaging but provides a good starting point.

Fixed the linter errors found by it. Also, added support to skip linting when applicable (e.g. when source is borrowed from internet). This feature skips running `clang-tidy` on all the files from a product. There's always more finer control using clang-tidy's [NOLINT and NOLINTNEXTLINE](https://clang.llvm.org/extra/clang-tidy/#suppressing-undesired-diagnostics) to suppress linting on individual lines in a source file.

Tested that it works as expected when enabled and also causes build to file (`$? = 2`). Also verified that the "NO_LINT" (mechanism to skip linting on all source files of a C/C++ product) works as expected.