### PR TITLE
build: format staged files as well with '-m' switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ OBJDIR_PREFIX := objs.
 # User must first build it and use a "buildenv shell" to build
 # source in this repo. All the non-build targets that works
 # both in and out of buildenv shell are filtered for this rule.
+# One more excpetion is $(flash) flag which is necessary on OSX.
 #
-ifeq ($(BUILDENV_SHELL),)
+ifeq ($(BUILDENV_SHELL)$(flash),)
 ifeq ($(filter clean% clobber %env format help%,$(MAKECMDGOALS)),)
 $(error Run "make env" first. See "make help")
 endif

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,8 @@ help:
 	@echo "               On/Off if defined/undefined [Default: not defined]"
 	@echo "      DRY_RUN: perform dry-run but do not apply changes"
 	@echo "               tgts: format"
+	@echo "      RELEASE: build optimized artifacts with release profile"
+	@echo "               debug build if undefined [Default: not defined]"
 	@echo "   DEV_SERIAL: s/n# of a st-link programmer (from \"st-info --probe\")"
 	@echo "               Useful when multiple boards are connected [Default: none]"
 	@echo

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -37,6 +37,10 @@ CC_EXTS := .cpp .cc
 CC_H_EXTS := .hpp .h .hh
 CC_EXTS_PATT := $(CC_EXTS:%=\%%)
 CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
+# Global C flags
+GLOBAL_CFLAGS := -Wall -g -O3
+# Global CXX flags
+GLOBAL_CXXFLAGS := --std=c++17 -Wextra -Wpedantic
 # PROTOBUF ARCH dependent CFLAGS and LFLAGS
 PROTOBUF_CFLAGS := -pthread -I/usr/local/$(ARCH)/include
 PROTOBUF_LFLAGS := -L/usr/local/$(ARCH)/lib -lprotobuf -lpthread

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -38,7 +38,7 @@ CC_H_EXTS := .hpp .h .hh
 CC_EXTS_PATT := $(CC_EXTS:%=\%%)
 CC_H_EXTS_PATT := $(CC_H_EXTS:%=\%%)
 # Global C flags
-GLOBAL_CFLAGS := -Wall -g -O3
+GLOBAL_CFLAGS := -Wall $(if $(RELEASE),-O3,-g -DDEBUG)
 # Global CXX flags
 GLOBAL_CXXFLAGS := --std=c++17 -Wextra -Wpedantic
 # PROTOBUF ARCH dependent CFLAGS and LFLAGS

--- a/build/Makefile.buildenv
+++ b/build/Makefile.buildenv
@@ -68,10 +68,10 @@ define buildenv_container
 endef
 
 define buildenv_img_check
-	if [[ "$$($(DOCKER_CMD) ps 2>&1)" =~ ^Got\ permission\ denied\ while\.* ]]; then \
+	if [ "$(BUILDENV_SHELL)" = "true" ] && [[ "$$($(DOCKER_CMD) ps 2>&1)" =~ ^Got\ permission\ denied\ while\.* ]]; then \
 		sudo chown -R $(THIS_USER):$(THIS_GROUP) $(DOCKER_SOCKET); \
 	fi; \
-	DOCKERFILE_VER=$$(git grep -h -i "version=" $(DOCKERFILE) | sed -n 's/^.*version="\([0-9a-fA-F]\{1\}.[0-9a-fA-F]\{1\}.[0-9a-fA-F]\{1\}\)".*$$/\1/p'); \
+	DOCKERFILE_VER=$$(git grep -h -i "^LABEL version=" $(DOCKERFILE) | sed -n 's/^.*version="\([0-9a-fA-F]\{1\}.[0-9a-fA-F]\{1\}.[0-9a-fA-F]\{1\}\)".*$$/\1/p'); \
 	DOCKERIMG_VER=$$($(DOCKER_CMD) inspect $(IMAGE_NAME) | jq -r '.[].Config.Labels.version'); \
 	if [ "$$DOCKERFILE_VER" != "$$DOCKERIMG_VER" ]; then \
 		printf "buildenv image version on this branch (disk-image: '%s' file-image: '%s'):\n" "$$DOCKERIMG_VER" "$$DOCKERFILE_VER" >&2; \

--- a/build/Makefile.cargo
+++ b/build/Makefile.cargo
@@ -18,7 +18,7 @@ CARGO_CROSS_COMPILE_TARGET :=
 endif
 
 CARGO_CROSS_COMPILE_TARGET_DIR := $(if $(CARGO_CROSS_COMPILE_TARGET),$(CARGO_CROSS_COMPILE_TARGET)/,)
-BINELF := $(PRODUCT_OBJDIR)/$(CARGO_CROSS_COMPILE_TARGET_DIR)debug/$(CARGO_PROJ)
+BINELF := $(PRODUCT_OBJDIR)/$(CARGO_CROSS_COMPILE_TARGET_DIR)$(if $(RELEASE),release,debug)/$(CARGO_PROJ)
 
 $(BINELF):: CARGO_TARGET_ARG := $(if $(CARGO_CROSS_COMPILE_TARGET),--target $(CARGO_CROSS_COMPILE_TARGET),)
 $(BINELF):: PRODIR := $(PRODIR)
@@ -26,7 +26,7 @@ $(BINELF):: PRODUCT_OBJDIR := $(PRODUCT_OBJDIR)
 $(BINELF):: BUILD_LOG := $(PRODUCT_OBJDIR)/build.log
 $(BINELF): | $(PRODUCT_OBJDIR)
 	@printf "%$(PCOL)s %s\n" "[CARGO]" $@ && printf "%$(PCOL)s %s %s\n" "" "Logs:" $(BUILD_LOG)
-	$(Q)$(CARGO) build --manifest-path $(PRODIR)/Cargo.toml --target-dir $(PRODUCT_OBJDIR) $(CARGO_TARGET_ARG) --jobs $(CORES) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
+	$(Q)$(CARGO) build $(if $(RELEASE),--release,) --manifest-path $(PRODIR)/Cargo.toml --target-dir $(PRODUCT_OBJDIR) $(CARGO_TARGET_ARG) --jobs $(CORES) > $(BUILD_LOG) 2>&1 || { tail -n 40 $(BUILD_LOG); exit 1; }
 
 all.$(PRODUCT): $(BINELF)
 	@true    # avoid "Nothing to be done for .."

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -16,18 +16,18 @@ OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)) $(PRODUCT_OBJDIR))
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))
 
-CFLAGS += -Wall -g -O3
+CFLAGS += $(GLOBAL_CFLAGS)
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += -static
 LFLAGS += $(DEP_LD)
-CXXFLAGS += --std=c++17
-
-# Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,cbin,$(C_BIN)))
+CXXFLAGS += $(GLOBAL_CXXFLAGS)
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
+
+# Add targets to detect change in C flags (after add_c_obj_tgts() as it changes flags)
+$(eval $(call cflags_change_tgt,cbin,$(C_BIN)))
 
 # Build dep .a first but omit those files while linking
 $(BINELF):: CXX := $(CXX)

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -18,19 +18,19 @@ OBJ_SUBDIRS += $(sort $(dir $(C_OBJS)) $(PRODUCT_OBJDIR))
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))
 
-CFLAGS += -Wall -g -O3 -fPIC
+CFLAGS += $(GLOBAL_CFLAGS) -fPIC
 CFLAGS += -I$(PRODUCT_OBJDIR)
 CFLAGS += $(H_INCS)
 CFLAGS += $(DEPINC)
 LFLAGS += -shared
 LFLAGS += $(DEP_LD)
-CXXFLAGS += --std=c++17
-
-# Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,clib,$(C_LIB)))
+CXXFLAGS += $(GLOBAL_CXXFLAGS)
 
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
+
+# Add targets to detect change in C flags (after add_c_obj_tgts() as it changes flags)
+$(eval $(call cflags_change_tgt,clib,$(C_LIB)))
 
 # Create symllink to each include header in target obj directory
 # Determine if include_prefix should be stripped and/or added

--- a/build/Makefile.protobuf
+++ b/build/Makefile.protobuf
@@ -14,11 +14,11 @@ OBJ_SUBDIRS += $(sort $(dir $(PB_CC_OBJS)))
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))
 
-CFLAGS += -fPIC $(PROTOBUF_CFLAGS)
+CFLAGS += $(GLOBAL_CFLAGS) -fPIC $(PROTOBUF_CFLAGS)
 CFLAGS += $(DEPINC)
 LFLAGS += -shared $(PROTOBUF_LFLAGS)
 LFLAGS += $(DEP_LD)
-CXXFLAGS += --std=c++17
+CXXFLAGS += $(GLOBAL_CXXFLAGS)
 
 # Add targets to generate .cc file from .proto files
 PB_CC_SRCS :=

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -23,18 +23,18 @@ OBJ_SUBDIRS += $(sort $(dir $(C_OBJS) $(S_OBJS)) $(PRODUCT_OBJDIR))
 # Dependency target, includes and LD paths (e.g. path/to/libdir:<C_LIB>)
 $(eval $(call eval_clib_deps))
 
-CFLAGS += $(STM32_CFLAGS)
+CFLAGS += $(GLOBAL_CFLAGS) $(STM32_CFLAGS)
 CFLAGS += $(H_INCS)
 CFLAGS += -DSTM32F401xE
 CFLAGS += $(DEPINC)
 LFLAGS += -Wl,--gc-sections -Wl,-n,--print-map,--cref,-Map,$(LD_MAP)
 LFLAGS += $(DEP_LD)
 
-# Add targets to detect change in C flags
-$(eval $(call cflags_change_tgt,stm32,$(STM32_ELF)))
-
 # Add targets for each .o file
 $(eval $(call add_c_obj_tgts,$(C_SRCS:%=$(PRODIR)/%)))
+
+# Add targets to detect change in C flags (after add_c_obj_tgts() as it changes flags)
+$(eval $(call cflags_change_tgt,stm32,$(STM32_ELF)))
 
 define S_OBJ_TGT
 $(1):: CC := $$(CC)

--- a/build/format.sh
+++ b/build/format.sh
@@ -118,7 +118,7 @@ clang_format_modified_files()
 
     # Find modified+newly staged C/C++ files (with "" arg) and all the
     # C/C++ files that are changed between top of master and this branch
-    for commit in "" "master..HEAD"; do
+    for commit in "" "--staged" "master..HEAD"; do
         modified_files+="$(eval git diff --name-only $commit $git_exts) "
     done
     clang_format_files "$modified_files"


### PR DESCRIPTION
build: allow "flash target" to work outside buildenv shell (for OSX)
build: /var/run/docker.sock ownership should be changed only from
       within buildenv shell
build: grep specific line while matching buildenv dockerfile version

Verified that `make format` works on staged files.
Verified that "flash targets" work out of buildenv shell on OSX.
Verified that buildenv dockerfile/image version check works as expected after the update.

---
build: refactor common C/C++ flags and make them global

Verified that change in flags (CFLAGS/CXXFLAGS) of a product forces rebuild.

---
build: added support to create build optimized release artifacts

Verified that specifying release build with `make RELEASE=1` forces rebuild of all products that supports release builds (i.e. C_BIN, C_LIB, STM32_ELF, CARGO_PROJ).