### PR TITLE
build: added support to specify and build packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 #
 PRODUCTS :=
 OBJ_SUBDIRS :=
-PACKAGES :=
+PKGS :=
 PRODTAR := {}
 
 #
@@ -73,7 +73,7 @@ $(sort $(OBJ_SUBDIRS)):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 tarball: $(patsubst %,tarball.%,$(PRODUCTS))
-pkg: $(patsubst %,pkg.%,$(PACKAGES))
+pkg: $(patsubst %,pkg.%,$(PKGS))
 ifeq ("$(origin ARCH)","command line")
 clean:
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(OBJDIR_PREFIX)$(ARCH)"

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
 
 #
-# Define pkg targets for entries in pkgs.json
+# Define pkg targets for entries in $(PKG_JSON)
 #
 $(eval $(call add_pkg_tgt))
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ endif
 OBJDIR_PREFIX := objs.
 
 #
+# Changeset info
+#
+DIRTY := $(filter X,$(lastword $(shell git describe --tags --all --dirty=' X')))
+CHANGESET := $(shell git log -1 --format=%h$(DIRTY))
+
+#
 # This repo ships with its build-environment. All the build
 # (vs clean etc) targets work as intended inside the buildenv.
 # User must first build it and use a "buildenv shell" to build
@@ -40,6 +46,8 @@ endif
 #
 PRODUCTS :=
 OBJ_SUBDIRS :=
+PACKAGES :=
+PRODTAR := {}
 
 #
 # Define targets for directories at the next level
@@ -48,6 +56,11 @@ THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 SUBDIRS := firmware libs cmds
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))
+
+#
+# Define pkg targets for entries in pkgs.json
+#
+$(eval $(call add_pkg_tgt))
 
 #
 # Common targets (after defining rules for targets at each level)
@@ -60,6 +73,7 @@ $(sort $(OBJ_SUBDIRS)):
 #
 all: $(patsubst %,all.%,$(PRODUCTS))
 tarball: $(patsubst %,tarball.%,$(PRODUCTS))
+pkg: $(patsubst %,pkg.%,$(PACKAGES))
 ifeq ("$(origin ARCH)","command line")
 clean:
 	@printf "%$(PCOL)s %s\n" "[RM]" "$(OBJDIR_PREFIX)$(ARCH)"
@@ -100,6 +114,7 @@ help:
 	@echo "          all: build all $(ARCH) products (default)"
 	@echo "        clean: remove all previously built $(ARCH) products"
 	@echo "      tarball: create individual tarball of previously built $(ARCH) products"
+	@echo "          pkg: create packages as defined in $(PKG_JSON_REL)"
 	@echo "     cleanall: remove all products for all targets architectues"
 	@echo "      clobber: cleanall + remove cscope/ctags"
 	@echo "       format: run 'clang-format' on new+modified files on this branch"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -407,7 +407,7 @@ endef
 #
 define pkg_tgt
 # For top Makefile
-PACKAGES += $(1)
+PKGS += $(1)
 
 # Use version string if specified, changeset string otherwise
 PKGVER := $$(shell jq -r '.$(1).version // empty' $(PKG_JSON))

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -414,9 +414,10 @@ PKGS += $(1)
 PKGVER := $$(shell jq -r '."$(1)".version // empty' $(PKG_JSON))
 PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 
-# Designated package path ($(ARCH) dependent)
+# Designated package path (architecture dependent)
+PKGARCH := $$(shell dpkg --print-architecture)
 PKGPATH_PREFIX := $(OBJDIR)/$(1)
-PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$(ARCH).tar
+PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$$(PKGARCH).tar
 PKGPATH_COMPRESSED := $$(PKGPATH).gz
 
 # Derive package tar file paths from deps

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -436,8 +436,8 @@ $$(PKGPATH_COMPRESSED): $$(PKGPATH)
 
 clean.pkg.$(1):: PKGPATH_PREFIX := $$(PKGPATH_PREFIX)
 clean.pkg.$(1):
-	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.tar*"
-	$(Q)rm -f $$(PKGPATH_PREFIX)*.tar*
+	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.{tar,tar.gz}"
+	$(Q)rm -f $$(PKGPATH_PREFIX)*.{tar,tar.gz}
 
 pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH_COMPRESSED))
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -24,6 +24,8 @@ Makefile.stm32 := $(_TOPDIR_)/build/Makefile.stm32
 Makefile.toolchain := $(_TOPDIR_)/build/Makefile.toolchain
 Makefile.zephyr := $(_TOPDIR_)/build/Makefile.zephyr
 CLANG_TIDY_CONFIG := $(_TOPDIR_)/.clang-tidy
+PKG_JSON := $(_TOPDIR_)/build/pkg.json
+PKG_JSON_REL := $(subst $(_TOPDIR_)/,,$(PKG_JSON))
 
 #
 # Common constants
@@ -164,6 +166,8 @@ define inc_rule
 PRODIR ?= $(shell realpath . --relative-to $(_TOPDIR_))
 # Prepend path and rule type to the product name to make it unique in that path
 PRODUCT := $$(PRODIR)__$(1)__$(2)
+# Product path
+PRODPATH := $$(PRODIR):$(2)
 # For top Makefile
 PRODUCTS += $$(PRODUCT)
 
@@ -349,6 +353,15 @@ endef
 
 
 #
+# Macro to create dictionary of product-path to its tarball path as JSON object
+# [in] - product path, product tarball path (i.e. tarball target name)
+#
+define update_prodtar
+PRODTAR := $$(if $(1),$$(shell echo '$$(PRODTAR)' | jq '. += { "$(1)" : "$(2)" }'),$$(PRODTAR))
+endef
+
+
+#
 # Common macro to add "tarball" target for a product
 # [in] - tarball target name, target deps, install prefix name (not value),
 #        transform path (optional)
@@ -371,4 +384,55 @@ $(1): $(2)
 	$(Q)if [ -n "$$^" ]; then \
 		tar hcf $$@ $$(INSTALL_MODE) $$^ --transform "s|$$(PROD_OBJDIR_PREFIX)|$$(INSTALL_PREFIX)|"; \
 	fi
+endef
+
+
+#
+# Wrapper BASH macro to concatenate multiple .tar files into one
+# [in] - path of combined .tar file to create, one or more constituent .tar files
+#
+define concat_tars
+	for f in $(2); do \
+		if [ -f "$$f" ]; then \
+			tar --concatenate -f $(1) --absolute-names $$f; \
+		fi; \
+	done
+endef
+
+
+#
+# Worker macro that defines target along with its tarball dependencies for
+# a package definition as described in $(PKG_JSON)
+# [in] - package name
+#
+define pkg_tgt
+# For top Makefile
+PACKAGES += $(1)
+
+# Use version string if specified, changeset string otherwise
+PKGVER := $$(shell jq -r '.$(1).version // empty' $(PKG_JSON))
+PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
+
+# Designated package path ($(ARCH) dependent)
+PKGPATH := $(OBJDIR)/$(1)-$(ARCH)-$$(PKGVER).tar
+
+# Derive package tar file paths from deps
+PKGDEPS := $$(sort $$(shell jq -r '.$(1).deps[] // empty' $(PKG_JSON) 2>/dev/null))
+ifeq ($$(PKGDEPS),)
+$$(error 'deps' is empty or missing for the entry '$(1)' in $(PKG_JSON_REL))
+endif
+PKGFILES := $$(foreach dep,$$(PKGDEPS),$$(shell echo '$$(PRODTAR)' | jq -r '."$$(dep)" // empty'))
+
+$$(PKGPATH): $$(PKGFILES)
+	@printf "%$(PCOL)s %s\n" "[PKG]" "$$@"
+	$(Q) $$(call concat_tars,$$@,$$^)
+
+pkg.$(1): $$(PKGPATH)
+endef
+
+#
+# Wrapper macro to "pkg_tgt" macro to add targets for all packages
+#
+define add_pkg_tgt
+$$(foreach pkg,$$(shell jq -r 'keys[]' $(PKG_JSON)),$$(eval $$(call pkg_tgt,$$(pkg))))
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -392,6 +392,7 @@ endef
 # [in] - path of combined .tar file to create, one or more constituent .tar files
 #
 define concat_tars
+	rm -f $(1) && \
 	for f in $(2); do \
 		if [ -f "$$f" ]; then \
 			tar --concatenate -f $(1) --absolute-names $$f; \
@@ -416,6 +417,7 @@ PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 # Designated package path ($(ARCH) dependent)
 PKGPATH_PREFIX := $(OBJDIR)/$(1)-$(ARCH)-
 PKGPATH := $$(PKGPATH_PREFIX)$$(PKGVER).tar
+PKGPATH_COMPRESSED := $$(PKGPATH).gz
 
 # Derive package tar file paths from deps
 PKGDEPS := $$(sort $$(shell jq -r '.$(1).deps[] // empty' $(PKG_JSON) 2>/dev/null))
@@ -428,12 +430,16 @@ $$(PKGPATH): $$(PKGFILES)
 	@printf "%$(PCOL)s %s\n" "[PKG]" "$$@"
 	$(Q)$$(call concat_tars,$$@,$$^)
 
+$$(PKGPATH_COMPRESSED): $$(PKGPATH)
+	@printf "%$(PCOL)s %s\n" "[GZIP]" "$$@"
+	$(Q)gzip -9 < $$^ > $$@
+
 clean.pkg.$(1):: PKGPATH_PREFIX := $$(PKGPATH_PREFIX)
 clean.pkg.$(1):
-	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.tar"
-	$(Q)rm -f $$(PKGPATH_PREFIX)*.tar
+	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.tar*"
+	$(Q)rm -f $$(PKGPATH_PREFIX)*.tar*
 
-pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH))
+pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH_COMPRESSED))
 endef
 
 #

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -425,7 +425,7 @@ PKGFILES := $$(foreach dep,$$(PKGDEPS),$$(shell echo '$$(PRODTAR)' | jq -r '."$$
 
 $$(PKGPATH): $$(PKGFILES)
 	@printf "%$(PCOL)s %s\n" "[PKG]" "$$@"
-	$(Q) $$(call concat_tars,$$@,$$^)
+	$(Q)$$(call concat_tars,$$@,$$^)
 
 pkg.$(1): $$(PKGPATH)
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -353,7 +353,7 @@ endef
 
 
 #
-# Macro to create dictionary of product-path to its tarball path as JSON object
+# Macro to create dictionary of { product-path, tarball-path } as JSON object
 # [in] - product path, product tarball path (i.e. tarball target name)
 #
 define update_prodtar

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -414,7 +414,8 @@ PKGVER := $$(shell jq -r '.$(1).version // empty' $(PKG_JSON))
 PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 
 # Designated package path ($(ARCH) dependent)
-PKGPATH := $(OBJDIR)/$(1)-$(ARCH)-$$(PKGVER).tar
+PKGPATH_PREFIX := $(OBJDIR)/$(1)-$(ARCH)-
+PKGPATH := $$(PKGPATH_PREFIX)$$(PKGVER).tar
 
 # Derive package tar file paths from deps
 PKGDEPS := $$(sort $$(shell jq -r '.$(1).deps[] // empty' $(PKG_JSON) 2>/dev/null))
@@ -427,7 +428,12 @@ $$(PKGPATH): $$(PKGFILES)
 	@printf "%$(PCOL)s %s\n" "[PKG]" "$$@"
 	$(Q)$$(call concat_tars,$$@,$$^)
 
-pkg.$(1): $$(PKGPATH)
+clean.pkg.$(1):: PKGPATH_PREFIX := $$(PKGPATH_PREFIX)
+clean.pkg.$(1):
+	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.tar"
+	$(Q)rm -f $$(PKGPATH_PREFIX)*.tar
+
+pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH))
 endef
 
 #

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -411,16 +411,16 @@ define pkg_tgt
 PKGS += $(1)
 
 # Use version string if specified, changeset string otherwise
-PKGVER := $$(shell jq -r '.$(1).version // empty' $(PKG_JSON))
+PKGVER := $$(shell jq -r '."$(1)".version // empty' $(PKG_JSON))
 PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 
 # Designated package path ($(ARCH) dependent)
-PKGPATH_PREFIX := $(OBJDIR)/$(1)-$(ARCH)-
-PKGPATH := $$(PKGPATH_PREFIX)$$(PKGVER).tar
+PKGPATH_PREFIX := $(OBJDIR)/$(1)
+PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$(ARCH).tar
 PKGPATH_COMPRESSED := $$(PKGPATH).gz
 
 # Derive package tar file paths from deps
-PKGDEPS := $$(sort $$(shell jq -r '.$(1).deps[] // empty' $(PKG_JSON) 2>/dev/null))
+PKGDEPS := $$(sort $$(shell jq -r '."$(1)".deps[] // empty' $(PKG_JSON) 2>/dev/null))
 ifeq ($$(PKGDEPS),)
 $$(error 'deps' is empty or missing for the entry '$(1)' in $(PKG_JSON_REL))
 endif

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -414,10 +414,9 @@ PKGS += $(1)
 PKGVER := $$(shell jq -r '."$(1)".version // empty' $(PKG_JSON))
 PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 
-# Designated package path (architecture dependent)
-PKGARCH := $$(shell dpkg --print-architecture)
+# Designated package path ($(ARCH) dependent)
 PKGPATH_PREFIX := $(OBJDIR)/$(1)
-PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$$(PKGARCH).tar
+PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$(ARCH).tar
 PKGPATH_COMPRESSED := $$(PKGPATH).gz
 
 # Derive package tar file paths from deps

--- a/build/Makefile.cbin
+++ b/build/Makefile.cbin
@@ -42,6 +42,8 @@ all.$(PRODUCT): $(BINELF)
 # No special install-prefix for a cbin
 CBIN_ELF_INSTALL_PREFIX :=
 $(eval $(call add_tarball_tgt,$(BIN_TARBALL),$(BINELF),BIN_INSTALL_PREFIX,$(CBIN_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
+# Add to [product path, tarball path] "dictionary"
+$(eval $(call update_prodtar,$(PRODPATH),$(BIN_TARBALL)))
 tarball.$(PRODUCT): $(BIN_TARBALL)
 	@true    # avoid "Nothing to be done for .."
 

--- a/build/Makefile.clib
+++ b/build/Makefile.clib
@@ -75,13 +75,11 @@ all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 CLIB_ELF_INSTALL_PREFIX :=
 $(eval $(call add_tarball_tgt,$(LIB_HDR_TARBALL),$(APIHDR),LIB_INCLUDE_INSTALL_PREFIX,$(CLIB_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
 $(eval $(call add_tarball_tgt,$(LIB_BIN_TARBALL),$(LIB_SO) $(LIB_AR),LIB_INSTALL_PREFIX,$(CLIB_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
+# Add to [product path, tarball path] "dictionary"
+$(eval $(call update_prodtar,$(PRODPATH),$(LIB_TARBALL)))
 $(LIB_TARBALL): $(LIB_BIN_TARBALL) $(LIB_HDR_TARBALL)
 	@printf "%$(PCOL)s %s\n" "[TAR]" "$@"
-	$(Q)for f in $^; do \
-		if [ -f "$$f" ]; then \
-			tar --concatenate -f $@ --absolute-names $$f; \
-		fi; \
-	 done;
+	$(Q)$(call concat_tars,$@,$^)
 
 tarball.$(PRODUCT): $(LIB_TARBALL)
 	@true    # avoid "Nothing to be done for .."

--- a/build/Makefile.stm32
+++ b/build/Makefile.stm32
@@ -70,6 +70,8 @@ all.$(PRODUCT): $(ELF) $(BIN) $(HEX)
 # Add STM32_ELF product directory to install path
 STM32_ELF_INSTALL_PREFIX := $(patsubst %/,%,$(dir $(PRODUCT_OBJDIR)))
 $(eval $(call add_tarball_tgt,$(FW_TARBALL),$(ELF) $(BIN) $(HEX) $(LD_MAP),FW_INSTALL_PREFIX,$(STM32_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
+# Add to [product path, tarball path] "dictionary"
+$(eval $(call update_prodtar,$(PRODPATH),$(FW_TARBALL)))
 tarball.$(PRODUCT): $(FW_TARBALL)
 	@true    # avoid "Nothing to be done for .."
 

--- a/build/Makefile.zephyr
+++ b/build/Makefile.zephyr
@@ -48,6 +48,8 @@ all.$(PRODUCT): $(ELF)
 # Zephyr app name should be part of install path
 ZEPHYR_APP_INSTALL_PREFIX := $(patsubst %/,%,$(dir $(PRODUCT_OBJDIR)))
 $(eval $(call add_tarball_tgt,$(FW_TARBALL),$(ELF) $(BIN) $(HEX) $(LD_MAP),FW_INSTALL_PREFIX,$(ZEPHYR_APP_INSTALL_PREFIX),TAR_INSTALL_MODE))
+# Add to [product path, tarball path] "dictionary"
+$(eval $(call update_prodtar,$(PRODPATH),$(FW_TARBALL)))
 tarball.$(PRODUCT): $(FW_TARBALL)
 	@true    # avoid "Nothing to be done for .."
 

--- a/build/pkg.json
+++ b/build/pkg.json
@@ -1,17 +1,17 @@
 {
-	"example_w_version" : {
-		"version" : "0.0.1",
-		"deps": [
-			"libs/common/hello:hello",
-			"libs/common/hello_cpp:hello_cpp",
-			"cmds/common/hello_world_cpp:hello_world_cpp",
-                        "firmware/nucleo/Lidar_Delivery:lidar_delivery"
-		]
-	},
-	"example_wo_version" : {
-		"deps": [
-                        "firmware/zephyr/hello_world:hello_world.nucleo_f401re",
-			"cmds/common/hello_world:hello_world"
-		]
-	}
+    "example_w_version" : {
+        "version" : "0.0.1",
+        "deps": [
+            "libs/common/hello:hello",
+            "libs/common/hello_cpp:hello_cpp",
+            "cmds/common/hello_world_cpp:hello_world_cpp",
+            "firmware/nucleo/Lidar_Delivery:lidar_delivery"
+        ]
+    },
+    "example_wo_version" : {
+        "deps": [
+            "firmware/zephyr/hello_world:hello_world.nucleo_f401re",
+            "cmds/common/hello_world:hello_world"
+        ]
+    }
 }

--- a/build/pkg.json
+++ b/build/pkg.json
@@ -1,0 +1,16 @@
+{
+	"example_w_version" : {
+		"version" : "0.0.1",
+		"deps": [
+			"libs/common/hello:hello",
+			"libs/common/hello_cpp:hello_cpp",
+			"cmds/common/hello_world_cpp:hello_world_cpp"
+		]
+	},
+	"example_wo_version" : {
+		"deps": [
+                        "firmware/zephyr/hello_world:hello_world.nucleo_f401re",
+			"cmds/common/hello_world:hello_world"
+		]
+	}
+}

--- a/build/pkg.json
+++ b/build/pkg.json
@@ -4,7 +4,8 @@
 		"deps": [
 			"libs/common/hello:hello",
 			"libs/common/hello_cpp:hello_cpp",
-			"cmds/common/hello_world_cpp:hello_world_cpp"
+			"cmds/common/hello_world_cpp:hello_world_cpp",
+                        "firmware/nucleo/Lidar_Delivery:lidar_delivery"
 		]
 	},
 	"example_wo_version" : {

--- a/build/pkg.json
+++ b/build/pkg.json
@@ -1,5 +1,5 @@
 {
-    "example_w_version" : {
+    "example-with-version" : {
         "version" : "0.0.1",
         "deps": [
             "libs/common/hello:hello",
@@ -8,7 +8,7 @@
             "firmware/nucleo/Lidar_Delivery:lidar_delivery"
         ]
     },
-    "example_wo_version" : {
+    "example-without-version" : {
         "deps": [
             "firmware/zephyr/hello_world:hello_world.nucleo_f401re",
             "cmds/common/hello_world:hello_world"


### PR DESCRIPTION
- Package definitions are specified in `build/pkg.json`
    o A package is collection of built products and this collection can be arbitrary
    o It is a mechanism to release built products in the repo
    o Individual standalone product (e.g. library, binary, f/w) is also envision to be a package
       with an entry in this file 
- Only "deps" key is mandatory
    o Invalid entries in "deps" are ignored
    o Duplicate entries are tolerated
    o Each entry must be a full target name (i.e. `<product_path>:<product_name>`).
       Otherwise it'll be treated as invalid entry.
- If "version" key is specified then that's used in package name otherwise
   changeset string is used. Format: `<pkg_name>-<arch>-<verstr>.tar`
- Use "clean=1" flag to clean package(s).

Testing
```
# build all packages for multiple ARCHs
$ make clobber
        [RM] objs.*
        [RM] cscope.* tags
$ make pkg -j $(nproc) && make pkg -j $(nproc) ARCH=arm
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-headers.tar
       [TAR] objs.aarch64/libs/common/hello/libhello-headers.tar
      [WEST] objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.elf
             Logs: objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/build.log
       [CXX] objs.aarch64/libs/common/hello_cpp/src/hello.o
       [CXX] objs.aarch64/cmds/common/hello_world_cpp/src/hello_world.o
        [CC] objs.aarch64/libs/common/hello/src/hello.o
        [CC] objs.aarch64/cmds/common/hello_world/src/hello_world.o
     [CXXLD] objs.aarch64/libs/common/hello/libhello.so
        [AR] objs.aarch64/libs/common/hello/libhello.a
       [TAR] objs.aarch64/libs/common/hello/libhello-bin.tar
     [CXXLD] objs.aarch64/cmds/common/hello_world/hello_world
       [TAR] objs.aarch64/libs/common/hello/libhello.tar
       [TAR] objs.aarch64/cmds/common/hello_world/hello_world.tar
3437 warnings generated.
4344 warnings generated.
        [AR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.a
     [CXXLD] objs.aarch64/libs/common/hello_cpp/libhello_cpp.so
     [CXXLD] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-bin.tar
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.tar
       [TAR] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp.tar
       [PKG] objs.aarch64/example_w_version-aarch64-0.0.1X.tar
       [TAR] objs.firmware/firmware/zephyr/hello_world/hello_world.nucleo_f401re.tar
       [PKG] objs.aarch64/example_wo_version-aarch64-f32b9e6X.tar
       [TAR] objs.arm/libs/common/hello_cpp/libhello_cpp-headers.tar
       [TAR] objs.arm/libs/common/hello/libhello-headers.tar
       [CXX] objs.arm/libs/common/hello_cpp/src/hello.o
       [CXX] objs.arm/cmds/common/hello_world_cpp/src/hello_world.o
        [CC] objs.arm/libs/common/hello/src/hello.o
        [CC] objs.arm/cmds/common/hello_world/src/hello_world.o
     [CXXLD] objs.arm/libs/common/hello/libhello.so
        [AR] objs.arm/libs/common/hello/libhello.a
     [CXXLD] objs.arm/cmds/common/hello_world/hello_world
       [TAR] objs.arm/libs/common/hello/libhello-bin.tar
       [TAR] objs.arm/libs/common/hello/libhello.tar
       [TAR] objs.arm/cmds/common/hello_world/hello_world.tar
       [PKG] objs.arm/example_wo_version-arm-d36a431.tar
3437 warnings generated.
4344 warnings generated.
        [AR] objs.arm/libs/common/hello_cpp/libhello_cpp.a
     [CXXLD] objs.arm/libs/common/hello_cpp/libhello_cpp.so
     [CXXLD] objs.arm/cmds/common/hello_world_cpp/hello_world_cpp
       [TAR] objs.arm/libs/common/hello_cpp/libhello_cpp-bin.tar
       [TAR] objs.arm/libs/common/hello_cpp/libhello_cpp.tar
       [TAR] objs.arm/cmds/common/hello_world_cpp/hello_world_cpp.tar
       [PKG] objs.arm/example_w_version-arm-0.0.1.tar

# observe the build packages
$ tar tvf objs.aarch64/example_w_version-aarch64-0.0.1X.tar
tar: Removing leading `/' from member names
-rwxr-xr-x popbot/popbot 2258920 2021-09-22 01:44 /usr/bin/hello_world_cpp
-rwxr-xr-x popbot/popbot   10728 2021-09-22 01:44 /usr/lib/libhello.so
-rw-r--r-- popbot/popbot    5866 2021-09-22 01:44 /usr/lib/libhello.a
-rw-rw-r-- popbot/popbot     158 2021-05-27 04:39 /usr/include/libhello/hello.h
-rwxr-xr-x popbot/popbot  132904 2021-09-22 01:44 /usr/lib/libhello_cpp.so
-rw-r--r-- popbot/popbot  196778 2021-09-22 01:44 /usr/lib/libhello_cpp.a
-rw-rw-r-- popbot/popbot     222 2021-06-18 18:35 /usr/include/libhello_cpp/hello.hpp
$ tar tvf objs.aarch64/example_wo_version-aarch64-f32b9e6X.tar
tar: Removing leading `/' from member names
-rwxr-xr-x popbot/popbot 605528 2021-09-22 01:44 /usr/bin/hello_world
-rwxr-xr-x popbot/popbot 559872 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.elf
-rwxr-xr-x popbot/popbot  13836 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.bin
-rw-r--r-- popbot/popbot  39020 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.hex
-rw-r--r-- popbot/popbot 266612 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.map

$ tar tvf objs.arm/example_w_version-arm-0.0.1.tar
tar: Removing leading `/' from member names
-rwxr-xr-x popbot/popbot 1711296 2021-09-22 01:44 /usr/bin/hello_world_cpp
-rwxr-xr-x popbot/popbot    9692 2021-09-22 01:44 /usr/lib/libhello.so
-rw-r--r-- popbot/popbot    4394 2021-09-22 01:44 /usr/lib/libhello.a
-rw-rw-r-- popbot/popbot     158 2021-05-27 04:39 /usr/include/libhello/hello.h
-rwxr-xr-x popbot/popbot  127752 2021-09-22 01:44 /usr/lib/libhello_cpp.so
-rw-r--r-- popbot/popbot  148302 2021-09-22 01:44 /usr/lib/libhello_cpp.a
-rw-rw-r-- popbot/popbot     222 2021-06-18 18:35 /usr/include/libhello_cpp/hello.hpp
$ tar tvf objs.arm/example_wo_version-arm-d36a431.tar
tar: Removing leading `/' from member names
-rwxr-xr-x popbot/popbot 418936 2021-09-22 01:44 /usr/bin/hello_world
-rwxr-xr-x popbot/popbot 559872 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.elf
-rwxr-xr-x popbot/popbot  13836 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.bin
-rw-r--r-- popbot/popbot  39020 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.hex
-rw-r--r-- popbot/popbot 266612 2021-09-22 01:44 /usr/lib/firmware/hello_world/nucleo_f401re/zephyr/zephyr.map
```
```
# build an individual package
$ make clobber
        [RM] objs.*
        [RM] cscope.* tags
$ make pkg.example_w_version -j $(nproc)
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-headers.tar
       [TAR] objs.aarch64/libs/common/hello/libhello-headers.tar
       [CXX] objs.aarch64/cmds/common/hello_world_cpp/src/hello_world.o
        [CC] objs.aarch64/libs/common/hello/src/hello.o
       [CXX] objs.aarch64/libs/common/hello_cpp/src/hello.o
        [AR] objs.aarch64/libs/common/hello/libhello.a
     [CXXLD] objs.aarch64/libs/common/hello/libhello.so
       [TAR] objs.aarch64/libs/common/hello/libhello-bin.tar
       [TAR] objs.aarch64/libs/common/hello/libhello.tar
3437 warnings generated.
4344 warnings generated.
        [AR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.a
     [CXXLD] objs.aarch64/libs/common/hello_cpp/libhello_cpp.so
     [CXXLD] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-bin.tar
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.tar
       [TAR] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp.tar
       [PKG] objs.aarch64/example_w_version-aarch64-0.0.1.tar
```
```
# clean a built package
$ make pkg.example_w_version clean=1

# clean all packages
$ make pkg clean=1
        [RM] objs.aarch64/example_w_version-aarch64-*.tar
        [RM] objs.aarch64/example_wo_version-aarch64-*.tar

# clean all packages for a target-arch
$ make pkg ARCH=arm clean=1
        [RM] objs.arm/example_w_version-arm-*.tar
        [RM] objs.arm/example_wo_version-arm-*.tar
```