### PR TITLE
build: added support to create .deb for .tar.gz package data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ help:
 	@echo "          all: build all $(ARCH) products (default)"
 	@echo "        clean: remove all previously built $(ARCH) products"
 	@echo "      tarball: create individual tarball of previously built $(ARCH) products"
-	@echo "          pkg: create packages as defined in $(PKG_JSON_REL)"
+	@echo "          pkg: create packages (.tar.gz and .deb) as defined in $(PKG_JSON_REL)"
 	@echo "     cleanall: remove all products for all targets architectues"
 	@echo "      clobber: cleanall + remove cscope/ctags"
 	@echo "       format: run 'clang-format' on new+modified files on this branch"

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,9 @@ include $(Makefile.ros)
 help:
 	@echo "Build Targets"
 	@echo "          all: build all $(ARCH) products (default)"
-	@echo "        clean: remove all previously built $(ARCH) products"
 	@echo "      tarball: create individual tarball of previously built $(ARCH) products"
 	@echo "          pkg: create packages (.tar.gz and .deb) as defined in $(PKG_JSON_REL)"
+	@echo "        clean: remove all previously built $(ARCH) products"
 	@echo "     cleanall: remove all products for all targets architectues"
 	@echo "      clobber: cleanall + remove cscope/ctags"
 	@echo "       format: run 'clang-format' on new+modified files on this branch"

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -26,6 +26,7 @@ Makefile.zephyr := $(_TOPDIR_)/build/Makefile.zephyr
 CLANG_TIDY_CONFIG := $(_TOPDIR_)/.clang-tidy
 PKG_JSON := $(_TOPDIR_)/build/pkg.json
 PKG_JSON_REL := $(subst $(_TOPDIR_)/,,$(PKG_JSON))
+GENDEB := $(_TOPDIR_)/build/gendeb.sh
 
 #
 # Common constants
@@ -51,10 +52,10 @@ PCOL := 12
 # For clang-tidy. Enumerate flags that clang doesn't support to filter them out
 CLANG_UNSUPPORTED_CFLAGS := -mcpu=cortex-m4 -mthumb-interwork
 # Default install prefix (can be overriden at command-line and by individual product makefiles)
-DEFAULT_LIB_INCLUDE_INSTALL_PREFIX ?= /usr/include
-DEFAULT_LIB_INSTALL_PREFIX ?= /usr/lib
-DEFAULT_BIN_INSTALL_PREFIX ?= /usr/bin
-DEFAULT_FW_INSTALL_PREFIX ?= /usr/lib/firmware
+DEFAULT_LIB_INCLUDE_INSTALL_PREFIX ?= usr/include
+DEFAULT_LIB_INSTALL_PREFIX ?= usr/lib
+DEFAULT_BIN_INSTALL_PREFIX ?= usr/bin
+DEFAULT_FW_INSTALL_PREFIX ?= usr/lib/firmware
 DEFAULT_TAR_INSTALL_MODE ?=
 
 #
@@ -395,7 +396,7 @@ define concat_tars
 	rm -f $(1) && \
 	for f in $(2); do \
 		if [ -f "$$f" ]; then \
-			tar --concatenate -f $(1) --absolute-names $$f; \
+			tar --concatenate --file $(1) $$f; \
 		fi; \
 	done
 endef
@@ -412,12 +413,19 @@ PKGS += $(1)
 
 # Use version string if specified, changeset string otherwise
 PKGVER := $$(shell jq -r '."$(1)".version // empty' $(PKG_JSON))
-PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
+TAR_PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),$(CHANGESET))
 
-# Designated package path ($(ARCH) dependent)
+# For debian packaging, we must use arch-string as emitted by "dpkg --print-architecture".
+# Use $(GENDEB) provided option to translate from "uname -m" to "dpkg --print-architecture".
+# Also, version string must start with a number. Use "0." as prefix when it's not specified.
+DEB_ARCH := $$(shell $(GENDEB) -A "$(ARCH)")
+DEB_PKGVER := $$(if $$(PKGVER),$$(PKGVER)$(DIRTY),0.$(CHANGESET))
+
+# Designated packaged tarball-path (ARCH dependent) and debian-path (DEB_ARCH dependent)
 PKGPATH_PREFIX := $(OBJDIR)/$(1)
-PKGPATH := $$(PKGPATH_PREFIX)_$$(PKGVER)_$(ARCH).tar
-PKGPATH_COMPRESSED := $$(PKGPATH).gz
+PKGPATH_TAR := $$(PKGPATH_PREFIX)_$$(TAR_PKGVER)_$$(ARCH).tar
+PKGPATH_DEB := $$(PKGPATH_PREFIX)_$$(DEB_PKGVER)_$$(DEB_ARCH).deb
+PKGPATH_TGZ := $$(PKGPATH_TAR:%.tar=%.tar.gz)
 
 # Derive package tar file paths from deps
 PKGDEPS := $$(sort $$(shell jq -r '."$(1)".deps[] // empty' $(PKG_JSON) 2>/dev/null))
@@ -426,20 +434,30 @@ $$(error 'deps' is empty or missing for the entry '$(1)' in $(PKG_JSON_REL))
 endif
 PKGFILES := $$(foreach dep,$$(PKGDEPS),$$(shell echo '$$(PRODTAR)' | jq -r '."$$(dep)" // empty'))
 
-$$(PKGPATH): $$(PKGFILES)
+$$(PKGPATH_TAR): $$(PKGFILES)
 	@printf "%$(PCOL)s %s\n" "[PKG]" "$$@"
 	$(Q)$$(call concat_tars,$$@,$$^)
 
-$$(PKGPATH_COMPRESSED): $$(PKGPATH)
+$$(PKGPATH_TGZ): $$(PKGPATH_TAR)
 	@printf "%$(PCOL)s %s\n" "[GZIP]" "$$@"
 	$(Q)gzip -9 < $$^ > $$@
 
+$$(PKGPATH_DEB):: DEB_PKGVER := $$(DEB_PKGVER)
+$$(PKGPATH_DEB):: DEB_ARCH := $$(DEB_ARCH)
+$$(PKGPATH_DEB): $$(PKGPATH_TGZ)
+	@printf "%$(PCOL)s %s\n" "[DEB]" "$$@"
+	$(Q)$(GENDEB) -p $(1) -v $$(DEB_PKGVER) -a $$(DEB_ARCH) -f "$$^" -o "$$(@D)" \
+		-m "$$(shell jq -r '."$(1)".maintainer // empty' $(PKG_JSON))" \
+		-d "$$(shell jq -r '."$(1)".depends // empty' $(PKG_JSON))" \
+		-s "$$(shell jq -r '."$(1)".description // empty' $(PKG_JSON))" \
+		$$(if $(DRY_RUN),-n, >/dev/null)
+
 clean.pkg.$(1):: PKGPATH_PREFIX := $$(PKGPATH_PREFIX)
 clean.pkg.$(1):
-	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.{tar,tar.gz}"
-	$(Q)rm -f $$(PKGPATH_PREFIX)*.{tar,tar.gz}
+	@printf "%$(PCOL)s %s\n" "[RM]" "$$(PKGPATH_PREFIX)*.{tar,tar.gz,deb}"
+	$(Q)rm -f $$(PKGPATH_PREFIX)*.{tar,tar.gz,deb}
 
-pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH_COMPRESSED))
+pkg.$(1): $$(if $$(clean),clean.pkg.$(1),$$(PKGPATH_DEB))
 endef
 
 #

--- a/build/gendeb.sh
+++ b/build/gendeb.sh
@@ -160,9 +160,10 @@ main()
     done
     shift $((OPTIND - 1))
 
-    # Check for mandatory args
+    # Check args
     [ -z "$pkgname" -o -z "$pkgver" -o -z "$arch" -o -z "$tarfile" ] && print_help "$0" && fail
     [ ! -f "$tarfile" ] && fail "'$tarfile' doesn't exist."
+    [ -n "$outdir" -a ! -d "$outdir" ] && fail "'$outdir' doesn't exist."
 
     gendeb "$pkgname" "$pkgver" "$arch" "$tarfile" "$description" "$maintainer" "$depends" "$license" "$outdir"
 }

--- a/build/gendeb.sh
+++ b/build/gendeb.sh
@@ -1,0 +1,170 @@
+#!/bin/bash -p
+
+DRY_RUN=false
+EXEC=eval
+
+fail()
+{
+    [ $# -gt 0 ] && echo "$*" 1>&2
+    exit 1
+}
+
+check_file_ext()
+{
+    local filename=$1
+    local filetype=
+
+    case "$filename" in
+        *.tar.gz|*.tgz) filetype="gzip compressed data" ;;
+        *) return 1 ;;
+    esac
+
+    [ "$(file -b $filename | awk -F, '{print $1}')" == "$filetype" ] && return 0 || return 1
+}
+
+uname_to_dpkg_arch()
+{
+    local uname_arch=$1
+    local dpkg_arch=
+
+    case "$uname_arch" in
+        x86_64|amd64) dpkg_arch=amd64 ;;
+        aarch64|arm64) dpkg_arch=arm64 ;;
+        arm|armv6l|armv7l|armhf) dpkg_arch=armhf ;;
+        *) ;;
+    esac
+
+    [ -z "$dpkg_arch" ] && return 1
+    echo "$dpkg_arch"
+}
+
+print_control()
+{
+    local pkgname=$1
+    local pkgver=$2
+    local arch=$3
+    local maintainer=$([ -n "$4" ] && echo "Maintainer: $4")
+    local depends=$([ -n "$5" ] && echo "Depends: $5")
+    local description=$([ -n "$6" ] && echo "Description: $6")
+    local license=$([ -n "$7" ] && echo "License: $7")
+
+    local depends_str=
+    local description_str=
+
+    local control=$(cat << EOM
+Package: $pkgname
+$maintainer
+Version: $pkgver
+Architecture: $arch
+$depends
+$description
+$license
+EOM
+)
+    echo "$control" | sed '/^$/d'
+}
+
+gendeb()
+{
+    local pkgname=$1
+    local pkgver=$2
+    local arch=$(uname_to_dpkg_arch "$3")
+    local tarfile=$(realpath $4)
+    local description=${5:-}
+    local maintainer=${6:-}
+    local depends=${7:-}
+    local license=${8:-}
+    local outdir=${9:-$(pwd)}
+
+    # Validate package name, version and arch strings
+    [[ "$pkgname" =~ ^.*_.*$ ]] && fail "Package name must not contain '_'."
+    [[ "$pkgver" =~ ^.*_.*$ ]] && fail "Package version must not contain '_'."
+    [ -z "$arch" ] && fail "Invalid ARCH string. Use one emitted from 'uname -m' or 'dpkg --print-architecture'"
+
+    # Validate input tarball
+    ! check_file_ext "$tarfile" && fail "Invalid file format. Must be gzip compressed data."
+
+    # Create tmpdir for building .deb and ensure that it's removed when script exits
+    local tmpdir=$(mktemp -d)
+    trap "rm -rf $tmpdir" INT EXIT
+
+    # Absolute path of generated .deb file
+    local pkg_prefix=${pkgname}_${pkgver}_${arch}
+    local pkgdir=$tmpdir/$pkg_prefix
+    local debdir=$pkgdir/DEBIAN
+    local debfile=$tmpdir/$pkg_prefix.deb
+
+    local build_steps=$(cat << EOM
+        (cd $tmpdir && \
+            mkdir -p $debdir && \
+            tar xfz $tarfile -C $pkgdir && \
+            print_control "$pkgname" "$pkgver" "$arch" "$maintainer" "$depends" "$description" "$license" > $debdir/control && \
+            dpkg-deb --build --root-owner-group $pkgdir)
+EOM
+)
+
+    local copy_steps=$(cat << EOM
+        cp -f $debfile $(realpath $outdir)/.
+EOM
+)
+
+    $EXEC "$build_steps && $copy_steps"
+}
+
+print_help()
+{
+    local prog_name=$(basename -s .sh "$1")
+    local HELPSTR=$(cat <<- EOM
+$prog_name -p <pkgname> -a <pkgarch> -v <pkgver> -f <pkgdata.tar.gz> [-s <description>] [-d <depends>] [-l <license>] [-m <maintainer>] [-o <outdir>] [-A <arch-string>] [-h]
+
+    Generate .deb file for a .tar.gz (gzip compressed data) file
+
+    -p  Package name (must not contain '_')
+    -a  Target architecture for the package (output of "dpkg --print-architecture" or "uname -m")
+    -v  Package version (must not contain '_')
+    -f  Gzip compressed data to create .deb for
+    -s  Package description string
+    -d  Package dependency list as comma separated strings
+    -l  Package license string
+    -m  Package maintainer string (recommended format: "name <email>")
+    -o  Output dir to place generated .deb file in
+    -A  Print dpkg-arch value (i.e. "dpkg --print-architecture") for <arch-string>
+    -n  Dry run (show commands that will run without executing them)
+    -h  Show this message
+EOM
+)
+    echo "$HELPSTR"
+}
+
+main()
+{
+    local arch= tarfile= license= description= depends= maintainer= outdir= pkgname= pkgver=
+
+    OPTIND=1
+    while getopts "A:a:d:f:hl:m:no:p:s:v:" arg; do
+        case $arg in
+            A) uname_to_dpkg_arch "$OPTARG"; exit $? ;;
+            a) arch=$OPTARG ;;
+            d) depends=$OPTARG ;;
+            f) tarfile=$OPTARG ;;
+            l) license=$OPTARG ;;
+            m) maintainer=$OPTARG ;;
+            n) DRY_RUN=true; EXEC=echo ;;
+            o) outdir=$OPTARG ;;
+            p) pkgname=$OPTARG ;;
+            s) description=$OPTARG ;;
+            v) pkgver=$OPTARG ;;
+            h) print_help "$0"; exit 0 ;;
+            ?) fail ;;
+        esac
+    done
+    shift $((OPTIND - 1))
+
+    # Check for mandatory args
+    [ -z "$pkgname" -o -z "$pkgver" -o -z "$arch" -o -z "$tarfile" ] && print_help "$0" && fail
+    [ ! -f "$tarfile" ] && fail "'$tarfile' doesn't exist."
+
+    gendeb "$pkgname" "$pkgver" "$arch" "$tarfile" "$description" "$maintainer" "$depends" "$license" "$outdir"
+}
+
+main "$@"

--- a/build/pkg.json
+++ b/build/pkg.json
@@ -1,6 +1,9 @@
 {
     "example-with-version" : {
         "version" : "0.0.1",
+        "maintainer" : "Place Holder <placeholder@email.com>",
+        "description" : "Example package containing version info",
+        "depends" : "dfu-util, tree",
         "deps": [
             "libs/common/hello:hello",
             "libs/common/hello_cpp:hello_cpp",
@@ -9,6 +12,9 @@
         ]
     },
     "example-without-version" : {
+        "maintainer" : "Place Holder <placeholder@email.com>",
+        "description" : "Example package that uses changeset info as version string",
+        "depends" : "curl",
         "deps": [
             "firmware/zephyr/hello_world:hello_world.nucleo_f401re",
             "cmds/common/hello_world:hello_world"


### PR DESCRIPTION
- Built product packaged as 
    o `.tar.gz` is targeted for use for rootfs overlay (e.g. buildroot)
    o `.deb` is targeted for use in a container
- ARCH string in
    o `.tar.gz` reflects value from `uname -m`.
    o `.deb` reflects value from `dpkg --print-architecture`.
- `build/pkg.json` still has `deps` as only mandatory field.
    When "version" is unspecified, `.tar.gz` uses `<changeset>` string whereas
    `.deb` uses `0.<changeset>` because Debian version must start with a digit.
- Difference between `make tarball` and `make pkg` is that former will build `.tar`
   files for _all_ [supported] products whereas latter will build `.tar` for only the ones
   specified in `build/pkg.json` and for their dependencies. Latter is much more efficient.

Testing
```
# basic build all packages
$ make clobber
        [RM] objs.*
        [RM] cscope.* tags

# "make pkg" only builds "deps" in `build/pkg.json`
$ make pkg -j $(nproc)
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-headers.tar
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/startup/startup_stm32f401xe.o
       [TAR] objs.aarch64/libs/common/hello/libhello-headers.tar
      [WEST] objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.elf
             Logs: objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/build.log
       [CXX] objs.aarch64/libs/common/hello_cpp/src/hello.o
       [CXX] objs.aarch64/cmds/common/hello_world_cpp/src/hello_world.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/Utilities/STM32F4xx-Nucleo/stm32f4xx_nucleo.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/VL53L1X_api.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/VL53L1X_calibration.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/platform.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/platform_specific.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/main.o
3437 warnings generated.
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/system_stm32f4xx.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/stm32f4xx_it.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/syscalls.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal.o
4344 warnings generated.
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_gpio.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_rcc_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_tim_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_i2c.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma2d.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/Legacy/stm32f4xx_hal_can.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_cortex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_usart.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_tim.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_rcc.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_uart.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_i2c_ex.o
        [CC] objs.aarch64/libs/common/hello/src/hello.o
     [CXXLD] objs.aarch64/libs/common/hello_cpp/libhello_cpp.so
        [CC] objs.aarch64/cmds/common/hello_world/src/hello_world.o
        [AR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.a
     [CXXLD] objs.aarch64/libs/common/hello/libhello.so
        [AR] objs.aarch64/libs/common/hello/libhello.a
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-bin.tar
     [CXXLD] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp
       [TAR] objs.aarch64/libs/common/hello/libhello-bin.tar
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp.tar
     [CXXLD] objs.aarch64/cmds/common/hello_world/hello_world
      [CCLD] objs.firmware/firmware/nucleo/Lidar_Delivery/lidar_delivery.elf
       [TAR] objs.aarch64/libs/common/hello/libhello.tar
       [TAR] objs.aarch64/cmds/common/hello_world/hello_world.tar
   [OBJCOPY] objs.firmware/firmware/nucleo/Lidar_Delivery/lidar_delivery.bin
   [OBJCOPY] objs.firmware/firmware/nucleo/Lidar_Delivery/lidar_delivery.hex
       [TAR] objs.firmware/firmware/nucleo/Lidar_Delivery/lidar_delivery.tar
       [TAR] objs.aarch64/cmds/common/hello_world_cpp/hello_world_cpp.tar
       [PKG] objs.aarch64/example-with-version_0.0.1_aarch64.tar
      [GZIP] objs.aarch64/example-with-version_0.0.1_aarch64.tar.gz
       [DEB] objs.aarch64/example-with-version_0.0.1_arm64.deb
       [TAR] objs.firmware/firmware/zephyr/hello_world/hello_world.nucleo_f401re.tar
       [PKG] objs.aarch64/example-without-version_1146637_aarch64.tar
      [GZIP] objs.aarch64/example-without-version_1146637_aarch64.tar.gz
       [DEB] objs.aarch64/example-without-version_0.1146637_arm64.deb
```
```
# verify that built `.deb` and its dependencies are installable (must specify absolute path of .deb for dependencies install)
$ sudo apt install -y $(realpath objs.aarch64/example-with-version_0.0.1
_arm64.deb)
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'example-with-version' instead of '/home/popbot/tejas/stm-main/objs.aarch64/example-with-version_0.0.1_arm64.deb'
The following additional packages will be installed:
  dfu-util tree
The following NEW packages will be installed:
  dfu-util example-with-version tree
0 upgraded, 3 newly installed, 0 to remove and 175 not upgraded.
Need to get 73.3 kB/936 kB of archives.
After this operation, 232 kB of additional disk space will be used.
Get:1 /home/popbot/tejas/stm-main/objs.aarch64/example-with-version_0.0.1_arm64.deb example-with-version arm64 0.0.1 [863 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports focal/universe arm64 tree arm64 1.8.0-1 [41.8 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports focal/universe arm64 dfu-util arm64 0.9-1 [31.5 kB]
Fetched 73.3 kB in 0s (174 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package tree.
(Reading database ... 129179 files and directories currently installed.)
Preparing to unpack .../tree_1.8.0-1_arm64.deb ...
Unpacking tree (1.8.0-1) ...
Selecting previously unselected package dfu-util.
Preparing to unpack .../dfu-util_0.9-1_arm64.deb ...
Unpacking dfu-util (0.9-1) ...
Selecting previously unselected package example-with-version.
Preparing to unpack .../example-with-version_0.0.1_arm64.deb ...
Unpacking example-with-version (0.0.1) ...
Setting up tree (1.8.0-1) ...
Setting up dfu-util (0.9-1) ...
Setting up example-with-version (0.0.1) ...
Processing triggers for man-db (2.9.1-1) ...

# and removable
$ sudo apt remove -y example-with-version dfu-util tree
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following packages will be REMOVED:
  dfu-util example-with-version tree
0 upgraded, 0 newly installed, 3 to remove and 175 not upgraded.
After this operation, 232 kB disk space will be freed.
(Reading database ... 129214 files and directories currently installed.)
Removing example-with-version (0.0.1) ...
dpkg: warning: while removing example-with-version, directory '/usr/lib/firmware' not empty so not removed
Removing dfu-util (0.9-1) ...
Removing tree (1.8.0-1) ...
Processing triggers for man-db (2.9.1-1) ...
```