### PR TITLE
build: basic sanity check for rules

### DIFF
--- a/buildtools/Makefile.buildenv
+++ b/buildtools/Makefile.buildenv
@@ -1,4 +1,4 @@
-DOCKERFILE := $(_TOPDIR_)/build/Dockerfile.buildenv
+DOCKERFILE := $(BUILDTOOLS)/Dockerfile.buildenv
 IMAGE_NAME := stm32_buildenv
 CONTAINER_NAME := $(IMAGE_NAME)$(subst /,.,$(subst $(HOME),,$(_TOPDIR_)))
 DOCKER_CMD := DOCKER_BUILDKIT=1 docker

--- a/buildtools/Makefile.cbin
+++ b/buildtools/Makefile.cbin
@@ -1,7 +1,7 @@
 ifdef C_BIN
 
 # Basic sanity check for this rule
-ifeq ($(C_SRCS),)
+ifeq ($(BUILDENV_SHELL)$(C_SRCS),true)
 $(error C_BIN: $(THIS_DIR)$(C_BIN)/Makefile has no input C_SRCS)
 endif
 

--- a/buildtools/Makefile.cbin
+++ b/buildtools/Makefile.cbin
@@ -1,5 +1,10 @@
 ifdef C_BIN
 
+# Basic sanity check for this rule
+ifeq ($(C_SRCS),)
+$(error C_BIN: $(THIS_DIR)$(C_BIN)/Makefile has no input C_SRCS)
+endif
+
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)

--- a/buildtools/Makefile.clib
+++ b/buildtools/Makefile.clib
@@ -1,5 +1,10 @@
 ifdef C_LIB
 
+# Basic sanity check for this rule
+ifeq ($(C_SRCS)$(I_HDRS),)
+$(error C_LIB: $(THIS_DIR)$(C_LIB)/Makefile has no input C_SRCS or I_HDRS)
+endif
+
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)
@@ -83,8 +88,16 @@ all.$(PRODUCT): $(LIB_SO) $(LIB_AR)
 
 # No special install-prefix for a clib
 CLIB_ELF_INSTALL_PREFIX :=
+ifneq ($(I_HDRS),)
 $(eval $(call add_tarball_tgt,$(LIB_HDR_TARBALL),$(APIHDR),LIB_INCLUDE_INSTALL_PREFIX,$(CLIB_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
+else
+LIB_HDR_TARBALL :=
+endif
+ifneq ($(C_SRCS),)
 $(eval $(call add_tarball_tgt,$(LIB_BIN_TARBALL),$(LIB_SO) $(LIB_AR),LIB_INSTALL_PREFIX,$(CLIB_ELF_INSTALL_PREFIX),TAR_INSTALL_MODE))
+else
+LIB_BIN_TARBALL :=
+endif
 # Add to [product path, tarball path] "dictionary"
 $(eval $(call update_prodtar,$(PRODPATH),$(LIB_TARBALL)))
 $(LIB_TARBALL): $(LIB_BIN_TARBALL) $(LIB_HDR_TARBALL)

--- a/buildtools/Makefile.clib
+++ b/buildtools/Makefile.clib
@@ -1,7 +1,7 @@
 ifdef C_LIB
 
 # Basic sanity check for this rule
-ifeq ($(C_SRCS)$(I_HDRS),)
+ifeq ($(BUILDENV_SHELL)$(C_SRCS)$(I_HDRS),true)
 $(error C_LIB: $(THIS_DIR)$(C_LIB)/Makefile has no input C_SRCS or I_HDRS)
 endif
 

--- a/buildtools/Makefile.clib
+++ b/buildtools/Makefile.clib
@@ -65,7 +65,7 @@ $(foreach hdr,$(I_HDRS),$(eval $(call HDR_SYMLINK_TGT,$(hdr))))
 $(LIB_SO):: C_SRCS := $(C_SRCS)
 $(LIB_SO):: CXX := $(CXX)
 $(LIB_SO):: LFLAGS := $(LFLAGS)
-$(LIB_SO): $(DEP_SO) $(DEP_AR) $(APIHDR) $(C_OBJS)
+$(LIB_SO): $(DEP_SO) $(APIHDR) $(C_OBJS)
 	$(Q)if [ -n "$(C_SRCS)" ]; then \
 		printf "%$(PCOL)s %s\n" "[CXXLD]" $@; \
 		$(CXX) $(LFLAGS) -o $@ $(filter-out $(CC_H_EXTS_PATT),$^); \

--- a/buildtools/Makefile.protobuf
+++ b/buildtools/Makefile.protobuf
@@ -1,7 +1,7 @@
 ifdef PROTO_LIB
 
 # Basic sanity check for this rule
-ifeq ($(PB_SRCS),)
+ifeq ($(BUILDENV_SHELL)$(PB_SRCS),true)
 $(error PROTO_LIB: $(THIS_DIR)$(PROTO_LIB)/Makefile has no input PB_SRCS)
 endif
 

--- a/buildtools/Makefile.protobuf
+++ b/buildtools/Makefile.protobuf
@@ -1,5 +1,10 @@
 ifdef PROTO_LIB
 
+# Basic sanity check for this rule
+ifeq ($(PB_SRCS),)
+$(error PROTO_LIB: $(THIS_DIR)$(PROTO_LIB)/Makefile has no input PB_SRCS)
+endif
+
 # This file defines rules for targets: [all|clean].$(PRODUCT)
 
 PRODUCT_OBJDIR := $(OBJDIR)/$(PRODIR)

--- a/buildtools/Makefile.stm32
+++ b/buildtools/Makefile.stm32
@@ -1,5 +1,10 @@
 ifdef STM32_ELF
 
+# Basic sanity check for this rule
+ifeq ($(C_SRCS)$(S_SRCS),)
+$(error STM32_ELF: $(THIS_DIR)$(STM32_ELF)/Makefile has no input C_SRCS or S_SRCS)
+endif
+
 # Override to use arm-none-eabi-gcc and, consequently, $(OBJDIR) location
 $(eval $(call inc_toolchain,firmware))
 

--- a/buildtools/Makefile.stm32
+++ b/buildtools/Makefile.stm32
@@ -1,7 +1,7 @@
 ifdef STM32_ELF
 
 # Basic sanity check for this rule
-ifeq ($(C_SRCS)$(S_SRCS),)
+ifeq ($(BUILDENV_SHELL)$(C_SRCS)$(S_SRCS),true)
 $(error STM32_ELF: $(THIS_DIR)$(STM32_ELF)/Makefile has no input C_SRCS or S_SRCS)
 endif
 

--- a/buildtools/Makefile.zephyr
+++ b/buildtools/Makefile.zephyr
@@ -1,7 +1,7 @@
 ifdef ZEPHYR_APP
 
 # Basic sanity check for this rule
-ifeq ($(BOARD),)
+ifeq ($(BUILDENV_SHELL)$(BOARD),true)
 $(error ZEPHYR_APP: $(THIS_DIR)$(ZEPHYR_APP)/Makefile has no input BOARD)
 endif
 

--- a/buildtools/Makefile.zephyr
+++ b/buildtools/Makefile.zephyr
@@ -1,5 +1,10 @@
 ifdef ZEPHYR_APP
 
+# Basic sanity check for this rule
+ifeq ($(BOARD),)
+$(error ZEPHYR_APP: $(THIS_DIR)$(ZEPHYR_APP)/Makefile has no input BOARD)
+endif
+
 # Override to use appropriate $(OBJDIR) location (toolchain is already selected by buildenv)
 $(eval $(call inc_toolchain,firmware))
 


### PR DESCRIPTION
That way, it provides some hint on what's expected as input for a product

- Fixed empty .a|.so in a .tar for a C_LIB containing only header files
- Fixed broken `buildtools/` path in Makefile.buildenv
- Fixed residual change in Makefile.clib from previous PR

Testing
```
# verified that it errors out when expected input params are absent
$ make cmds/common/hello_world
/home/popbot/tejas/stm-main/buildtools/Makefile.cbin:5: *** C_BIN: cmds/common/hello_world/Makefile has no input C_SRCS.  Stop.

# also verified normal operation when no input params are missing
$ make clobber && make -j $(nproc)
```
```
# Basic testing for empty .a|.so fix
$ make -j $(nproc) libs/cutils/types/ clean=1
        [RM] objs.aarch64/libs/cutils/types/libtypes.so|.a|.tar
$ make -j $(nproc) libs/cutils/types/ tarball=1
       [TAR] objs.aarch64/libs/cutils/types/libtypes-headers.tar
       [TAR] objs.aarch64/libs/cutils/types/libtypes.tar
$ tar tvf objs.aarch64/libs/cutils/types/libtypes.tar
-rw-rw-r-- popbot/popbot   336 2021-09-28 09:56 usr/include/cutils/types.h
```