### PR TITLE
cutils/alloc: wrapper library with ease-of-use memory alloc APIs

### DIFF
--- a/buildtools/pkg.json
+++ b/buildtools/pkg.json
@@ -5,8 +5,7 @@
         "description" : "Example package containing version info",
         "depends" : "dfu-util, tree",
         "deps": [
-            "libs/common/hello:hello",
-            "libs/common/hello_cpp:hello_cpp",
+            "libs/cutils/list:list",
             "cmds/common/hello_world_cpp:hello_world_cpp",
             "firmware/nucleo/Lidar_Delivery:lidar_delivery"
         ]

--- a/libs/cutils/Makefile
+++ b/libs/cutils/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := types
+SUBDIRS := alloc types
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/Makefile
+++ b/libs/cutils/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := alloc list time types
+SUBDIRS := alloc list time timeout_list types
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/Makefile
+++ b/libs/cutils/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := alloc types
+SUBDIRS := alloc time types
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/Makefile
+++ b/libs/cutils/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := alloc time types
+SUBDIRS := alloc list time types
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/alloc/Makefile
+++ b/libs/cutils/alloc/Makefile
@@ -1,0 +1,19 @@
+C_LIB := alloc
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS :=
+# "hdrs"
+I_HDRS := include/alloc.h
+
+# "deps"
+DEPEND :=
+
+# strip_include_prefix
+STRIP_INC_PREFIX := include
+# include_prefix
+INC_PREFIX := cutils
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/cutils/alloc/include/alloc.h
+++ b/libs/cutils/alloc/include/alloc.h
@@ -1,0 +1,100 @@
+#ifndef CUTILS_ALLOC_H
+#define CUTILS_ALLOC_H
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * @brief  Worker function that allocates memory of requested size.
+ *         The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] count  Number of objects to allocate
+ * @param[in] size   Size of each object
+ * @param[in] nb     Flag for non-blocking call (if true returns immediately
+ *                   when calloc() fails)
+ *
+ * @return  Pointer to allocated memory
+ */
+static inline void *
+_zalloc(size_t count, size_t size, bool nb)
+{
+    void *ptr;
+    while ((ptr = calloc(count, size)) == NULL) {
+        if (nb) {
+            break;
+        } else {
+            usleep(1000);
+        }
+    }
+    return ptr;
+}
+
+/*
+ * @brief  Wrapper function to try to allocate memory till it succeeds (blocking
+ *         call). The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] count  Number of objects to allocate
+ * @param[in] size   Size of each object
+ *
+ * @return  Pointer to allocated memory (or blocks indefinitely till _zcalloc()
+ *          succeeds)
+ */
+static inline void *
+zalloc(size_t count, size_t size)
+{
+    return _zalloc(count, size, false);
+}
+
+/*
+ * @brief  Wrapper function to allocate memory (non-blocking call)
+ *         The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] count  Number of objects to allocate
+ * @param[in] size   Size of each object
+ *
+ * @return  Pointer to allocated memory, NULL if failed
+ */
+static inline void *
+zalloc_nb(size_t count, size_t size)
+{
+    return _zalloc(count, size, true);
+}
+
+/*
+ * @brief  Wrapper function to try to allocate memory till it succeeds (blocking
+ *         call). The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] size   Size of memory to allocate
+ *
+ * @return  Pointer to allocated memory (or blocks indefinitely till _zcalloc()
+ *          succeeds)
+ */
+static inline void *
+zmalloc(size_t size)
+{
+    return _zalloc(1, size, false);
+}
+
+/*
+ * @brief  Wrapper function to allocate memory (non-blocking call).
+ *         The allocated memory is filled with bytes of value zero.
+ *
+ * @param[in] size   Size of memory to allocate
+ *
+ * @return  Pointer to allocated memory, NULL if failed
+ */
+static inline void *
+zmalloc_nb(size_t size)
+{
+    return _zalloc(1, size, true);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_ALLOC_H

--- a/libs/cutils/list/Makefile
+++ b/libs/cutils/list/Makefile
@@ -1,0 +1,19 @@
+C_LIB := list
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS :=
+# "hdrs"
+I_HDRS := include/list.h
+
+# "deps"
+DEPEND :=
+
+# strip_include_prefix
+STRIP_INC_PREFIX := include
+# include_prefix
+INC_PREFIX := cutils
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/cutils/list/include/list.h
+++ b/libs/cutils/list/include/list.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CUTILS_LIST_H
+#define CUTILS_LIST_H
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Inline doubly-linked list routines
+ *
+ * list_init(l, off)            initialize a list; nodes at offset 'off'
+ * list_fini(l)                 finish using a list; must be empty
+ * list_prev(l, n)              return node before n, NULL if none
+ * list_next(l, n)              return node after n, NULL if none
+ * list_head(l)                 return list head, NULL if empty
+ * list_tail(l)                 return list tail, NULL if empty
+ * list_insert_before(l, b, n)  insert node n before b
+ * list_insert_after(l, a, n)   insert node n after a
+ * list_insert_head(l, n)       insert node n at head of the list
+ * list_insert_tail(l, n)       insert node n at tail of the list
+ * list_delete(l, n)            delete node n from the list
+ * list_delete_head(l)          delete head of the list and return it, or NULL
+ * list_delete_tail(l)          delete tail of the list and return it, or NULL
+ * list_empty(l)                return true if the list is empty, false if not
+ * list_move(src, dst)          move src to dst and clear src
+ * list_node_swap(l, n1, n2)    swap nodes n1 and n2, both must be non-NULL
+ */
+
+struct list_node;
+
+typedef struct list_node {
+    struct list_node *n_prev;
+    struct list_node *n_next;
+} list_node_t;
+
+typedef struct {
+    size_t l_off;
+    list_node_t l_anchor;
+} list_t;
+
+static inline void *__attribute__((always_inline)) __attribute__((pure))
+list_node_to_data(const list_t *l, const list_node_t *n)
+{
+    if (n == &l->l_anchor) {
+        return NULL;
+    }
+    return (void *)((uintptr_t)n - l->l_off);
+}
+
+static inline list_node_t *__attribute__((always_inline)) __attribute__((pure))
+list_node_from_data(const list_t *l, const void *data)
+{
+    if (data == NULL) {
+        return (list_node_t *)&l->l_anchor;
+    }
+    return (list_node_t *)((uintptr_t)data + l->l_off);
+}
+
+static inline void __attribute__((always_inline))
+list_node_insert(list_node_t *t, list_node_t *p, list_node_t *n)
+{
+    p->n_next = t;
+    t->n_prev = p;
+    t->n_next = n;
+    n->n_prev = t;
+}
+
+static inline void __attribute__((always_inline))
+list_node_delete(list_node_t *t)
+{
+    list_node_t *p = t->n_prev;
+    list_node_t *n = t->n_next;
+
+    p->n_next = n;
+    n->n_prev = p;
+    t->n_next = NULL;
+    t->n_prev = NULL;
+}
+
+static inline void
+list_init(list_t *l, size_t off)
+{
+    l->l_off = off;
+    list_node_insert(&l->l_anchor, &l->l_anchor, &l->l_anchor);
+}
+
+static inline void
+list_fini(list_t *l)
+{
+    assert(l->l_anchor.n_next == &l->l_anchor);
+    assert(l->l_anchor.n_prev == &l->l_anchor);
+    list_node_delete(&l->l_anchor);
+}
+
+static inline void *__attribute__((always_inline))
+list_prev(list_t *l, void *target)
+{
+    return list_node_to_data(l, list_node_from_data(l, target)->n_prev);
+}
+
+static inline void *__attribute__((always_inline))
+list_next(list_t *l, void *target)
+{
+    return list_node_to_data(l, list_node_from_data(l, target)->n_next);
+}
+
+static inline void *__attribute__((always_inline)) list_head(list_t *l)
+{
+    return list_next(l, NULL);
+}
+
+static inline void *__attribute__((always_inline)) list_tail(list_t *l)
+{
+    return list_prev(l, NULL);
+}
+
+static inline void __attribute__((always_inline))
+list_insert_before(list_t *l, void *before, void *target)
+{
+    list_node_t *t = list_node_from_data(l, target);
+    list_node_t *n = list_node_from_data(l, before);
+    list_node_t *p = n->n_prev;
+
+    list_node_insert(t, p, n);
+}
+
+static inline void __attribute__((always_inline))
+list_insert_after(list_t *l, void *after, void *target)
+{
+    list_node_t *t = list_node_from_data(l, target);
+    list_node_t *p = list_node_from_data(l, after);
+    list_node_t *n = p->n_next;
+
+    list_node_insert(t, p, n);
+}
+
+static inline void __attribute__((always_inline))
+list_insert_head(list_t *l, void *target)
+{
+    list_insert_after(l, NULL, target);
+}
+
+static inline void __attribute__((always_inline))
+list_insert_tail(list_t *l, void *target)
+{
+    list_insert_before(l, NULL, target);
+}
+
+static inline void __attribute__((always_inline))
+list_delete(list_t *l, void *target)
+{
+    list_node_delete(list_node_from_data(l, target));
+}
+
+static inline void *__attribute__((always_inline)) list_delete_head(list_t *l)
+{
+    void *head = list_head(l);
+
+    if (head) {
+        list_delete(l, head);
+    }
+    return head;
+}
+
+static inline void *__attribute__((always_inline)) list_delete_tail(list_t *l)
+{
+    void *tail = list_tail(l);
+
+    if (tail) {
+        list_delete(l, tail);
+    }
+    return tail;
+}
+
+static inline bool __attribute__((always_inline)) list_empty(list_t *l)
+{
+    return list_head(l) == NULL;
+}
+
+static inline void
+list_move(list_t *src, list_t *dst)
+{
+    list_init(dst, src->l_off);
+    if (src->l_anchor.n_prev != &src->l_anchor) {
+        list_node_insert(&dst->l_anchor, src->l_anchor.n_prev,
+                         src->l_anchor.n_next);
+        list_node_insert(&src->l_anchor, &src->l_anchor, &src->l_anchor);
+    }
+}
+
+static inline void
+list_node_swap(list_t *l, void *t1, void *t2)
+{
+    assert(t1 && t2);
+
+    if (t1 != t2) {
+        void *t1_prev = list_prev(l, t1);
+        void *t2_prev = list_prev(l, t2);
+        if (t1 == t2_prev) {
+            list_delete(l, t1);
+            list_insert_after(l, t2, t1);
+        } else if (t2 == t1_prev) {
+            list_delete(l, t2);
+            list_insert_after(l, t1, t2);
+        } else {
+            list_delete(l, t1);
+            list_delete(l, t2);
+            list_insert_after(l, t2_prev, t1);
+            list_insert_after(l, t1_prev, t2);
+        }
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_LIST_H

--- a/libs/cutils/time/Makefile
+++ b/libs/cutils/time/Makefile
@@ -1,0 +1,19 @@
+C_LIB := time
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS :=
+# "hdrs"
+I_HDRS := include/time.h
+
+# "deps"
+DEPEND :=
+
+# strip_include_prefix
+STRIP_INC_PREFIX := include
+# include_prefix
+INC_PREFIX := cutils
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/cutils/time/include/time.h
+++ b/libs/cutils/time/include/time.h
@@ -1,0 +1,67 @@
+#ifndef CUTILS_TIME_H
+#define CUTILS_TIME_H
+
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * @brief  Get current timestamp with nanosecond granularity.
+ *         Uses CLOCK_MONOTNOIC_RAW. Good for testing short durations.
+ *
+ * @return  64bit current timestamp value in nanoseconds
+ */
+static inline uint64_t
+gettsc(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    return ts.tv_sec * 1000000000 + ts.tv_nsec;
+}
+
+/*
+ * @brief  Get current timestamp with microsecond granularity.
+ *         Uses CLOCK_MONOTNOIC_RAW. Good for testing short durations.
+ *
+ * @return  64bit current timestamp value in microseconds
+ */
+static inline uint64_t
+gettsc_us(void)
+{
+    return gettsc() / 1000;
+}
+
+/*
+ * @brief  Get current timestamp with millisecond granularity.
+ *         Uses CLOCK_MONOTNOIC_RAW. Good for testing short durations.
+ *
+ * @return  64bit current timestamp value in milliseconds
+ */
+static inline uint64_t
+gettsc_ms(void)
+{
+    return gettsc() / 1000000;
+}
+
+/*
+ * @brief  Get timestamp from given duration (in milliseconds) from now.
+ *
+ * @param[in] ms  Duration in milliseconds
+ *
+ * @return  64bit timestamp value [in future or past] in milliseconds from
+ *          current value
+ */
+static inline uint64_t
+get_timestamp_ms(int64_t ms)
+{
+    return gettsc_ms() + ms;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_TIME_H

--- a/libs/cutils/timeout_list/Makefile
+++ b/libs/cutils/timeout_list/Makefile
@@ -1,0 +1,27 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+C_LIB := timeout_list
+
+# "includes"
+H_DIRS := include
+# "srcs"
+C_SRCS := src/timeout_list.c
+# "hdrs"
+I_HDRS := include/timeout_list.h
+
+# "deps"
+DEPEND := libs/cutils/alloc:alloc libs/cutils/list:list libs/cutils/time:time  libs/cutils/types:types
+
+# strip_include_prefix
+STRIP_INC_PREFIX := include
+# include_prefix
+INC_PREFIX := cutils
+
+LFLAGS += -pthread
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))
+
+# add test directory
+SUBDIRS := test
+$(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/timeout_list/include/timeout_list.h
+++ b/libs/cutils/timeout_list/include/timeout_list.h
@@ -1,0 +1,65 @@
+#ifndef CUTILS_TIMEOUT_LIST_H
+#define CUTILS_TIMEOUT_LIST_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct timeout_list_ctx tolist_ctx_t; // timeout_list context handle
+
+/*
+ * @brief Initialize a [thread-safe] timeout-list
+ *        A timeout-list timestamps the entries inserted in it and guarantees
+ *        to return entries no older than user specified timeout value. Older
+ *        entries are automatically deallocated and deleted from the list.
+ *
+ * @param[in] timeout_ms  Timeout value in milliseconds
+ * @param[in] entsz       Size of each entry in the list
+ *
+ * @return  Context handle for the timeout-list if success, NULL otherwise
+ */
+extern tolist_ctx_t *timout_list_init(uint64_t timeout_ms, size_t entsz);
+
+/*
+ * @brief Destroy a previously created timeout-list
+ *
+ * @param[in] ctx  Context handle for previously created timeout-list
+ */
+extern void timeout_list_fini(tolist_ctx_t *ctx);
+
+/*
+ * @brief  Insert an entry in timeout-list
+ *         The entry must be of size same as the list was initialized with.
+ *         Memory is allocated for the entry by the list.
+ *
+ * @param[in] ctx  Context handle for previously created timeout-list
+ * @param[in] ent  Data entry to insert in the list
+ *
+ * @return  If success 0, negative errno otherwise
+ *          -ENOMEM  Failed to allocate memory for ent
+ */
+extern int timout_list_put(tolist_ctx_t *ctx, void *ent);
+
+/*
+ * @brief  Retrieve entries from the timeout-list (newest entries first)
+ *         Retrieved entries aren't immediately deleted from the list
+ *         but only when they are expired which is determined at the
+ *         time of this API call.
+ *
+ * @param[in] ctx    Context handle for previously created timeout-list
+ * @param[in] buf    Input buffer to store retrieved entries in
+ * @param[in] bufsz  Size of input buffer (must be >= entsz at list init)
+ *
+ * @return  Number of bytes written in input buffer if success, negative errno
+ *          otherwise
+ *          -EINVAL  Insufficient bufsz
+ */
+extern int timout_list_get(tolist_ctx_t *ctx, void *buf, size_t bufsz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_TIMEOUT_LIST_H

--- a/libs/cutils/timeout_list/include/timeout_list_priv.h
+++ b/libs/cutils/timeout_list/include/timeout_list_priv.h
@@ -1,0 +1,48 @@
+#ifndef CUTILS_TIMEOUT_LIST_PRIV_H
+#define CUTILS_TIMEOUT_LIST_PRIV_H
+
+#include <pthread.h>
+#include <cutils/list.h>
+#include <cutils/timeout_list.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// timeout-list context definition
+typedef struct timeout_list_ctx {
+    uint64_t timeout_ms;
+    size_t entsz;
+    list_t l;
+    pthread_mutex_t mut;
+} tolist_ctx_t;
+
+// list node containg a timout-list entry
+typedef struct {
+    void *ent;
+    uint64_t ts_ms;
+    list_node_t node;
+} tolist_ent_t;
+
+/*
+ * @brief  Allocate memory for an entry node in a timeout-list
+ *
+ * @param[in] ctx  Context handle for previously created timeout-list
+ * @param[in] ent  Entry data
+ *
+ * @return  Pointer to allocated entry if success, NULL otherwise
+ */
+extern tolist_ent_t *alloc_tolist_ent(tolist_ctx_t *ctx, void *ent);
+
+/*
+ * @brief  Free memory of previously allocated timeout-list node
+ *
+ * @param[in] ent  Previously allocated entry node
+ */
+extern void free_tolist_ent(tolist_ent_t *ent);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_TIMEOUT_LIST_PRIV_H

--- a/libs/cutils/timeout_list/src/timeout_list.c
+++ b/libs/cutils/timeout_list/src/timeout_list.c
@@ -1,0 +1,109 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <string.h>
+#include <time.h>
+
+#include <cutils/alloc.h>
+#include <cutils/list.h>
+#include <cutils/time.h>
+#include <cutils/types.h>
+#include "timeout_list.h"
+#include "timeout_list_priv.h"
+
+tolist_ctx_t *
+timout_list_init(uint64_t timeout_ms, size_t entsz)
+{
+    tolist_ctx_t *ctx = zmalloc(sizeof(tolist_ctx_t));
+    ctx->timeout_ms = timeout_ms;
+    ctx->entsz = entsz;
+    list_init(&ctx->l, offsetof(tolist_ent_t, node));
+    pthread_mutex_init(&ctx->mut, NULL);
+    return ctx;
+}
+
+void
+timeout_list_fini(tolist_ctx_t *ctx)
+{
+    if (ctx) {
+        pthread_mutex_lock(&ctx->mut);
+        tolist_ent_t *e = NULL;
+        while ((e = list_delete_tail(&ctx->l))) {
+            free_tolist_ent(e);
+        }
+        list_fini(&ctx->l);
+        pthread_mutex_unlock(&ctx->mut);
+        pthread_mutex_destroy(&ctx->mut);
+        free(ctx);
+    }
+}
+
+tolist_ent_t *
+alloc_tolist_ent(tolist_ctx_t *ctx, void *ent)
+{
+    tolist_ent_t *e = zmalloc(sizeof(tolist_ent_t));
+    e->ent = zmalloc(ctx->entsz);
+    memcpy(e->ent, ent, ctx->entsz); // NOLINT
+    e->ts_ms = gettsc_ms();
+    return e;
+}
+
+void
+free_tolist_ent(tolist_ent_t *ent)
+{
+    if (ent) {
+        if (ent->ent) {
+            free(ent->ent);
+        }
+        free(ent);
+    }
+}
+
+int
+timout_list_put(tolist_ctx_t *ctx, void *ent)
+{
+    assert(ctx && ent);
+    int err = 0;
+    pthread_mutex_lock(&ctx->mut);
+    tolist_ent_t *e = alloc_tolist_ent(ctx, ent);
+    if (!e) {
+        err = -ENOMEM;
+    } else {
+        list_insert_head(&ctx->l, e);
+    }
+    pthread_mutex_unlock(&ctx->mut);
+    return err;
+}
+
+int
+timout_list_get(tolist_ctx_t *ctx, void *buf, size_t bufsz)
+{
+    assert(ctx && buf);
+    if (bufsz < ctx->entsz) {
+        return -EINVAL;
+    }
+
+    int off = 0;
+    pthread_mutex_lock(&ctx->mut);
+    if (!list_empty(&ctx->l)) {
+        tolist_ent_t *e = NULL;
+        uint64_t ts_ms = get_timestamp_ms(-ctx->timeout_ms);
+
+        // first discard entries older than timeout
+        while ((e = list_tail(&ctx->l)) && e->ts_ms <= ts_ms) {
+            list_delete(&ctx->l, e);
+            free_tolist_ent(e);
+        }
+
+        // remaining entries meet the "freshness" criterion
+        for (e = list_head(&ctx->l); e && off < bufsz;
+             e = list_next(&ctx->l, e)) {
+            memcpy(buf + off, e->ent, MIN(bufsz - off, ctx->entsz)); // NOLINT
+            off += ctx->entsz;
+        }
+    }
+    pthread_mutex_unlock(&ctx->mut);
+    return off;
+}

--- a/libs/cutils/timeout_list/test/Makefile
+++ b/libs/cutils/timeout_list/test/Makefile
@@ -1,0 +1,14 @@
+C_BIN := timeout_list_test
+
+# "includes"
+H_DIRS :=
+# "srcs"
+C_SRCS := src/timeout_list_test.c
+
+# "deps"
+DEPEND := libs/cutils/timeout_list:timeout_list libs/cutils/time:time
+
+LFLAGS += -pthread
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,cbin,$(C_BIN)))

--- a/libs/cutils/timeout_list/test/src/timeout_list_test.c
+++ b/libs/cutils/timeout_list/test/src/timeout_list_test.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <cutils/time.h>
+#include <cutils/timeout_list.h>
+
+// Test a timeout-list where retrieved entries are not older than 100ms
+#define TIMEOUT_MS 100
+
+int
+main(void)
+{
+    int err = 0;
+
+    // Init a timeout-list with entry size of 8 bytes
+    tolist_ctx_t *tolctx = timout_list_init(TIMEOUT_MS, sizeof(uint64_t));
+
+    // Push an entry
+    uint64_t ts0 = gettsc();
+    err = timout_list_put(tolctx, &ts0);
+    assert(err == 0);
+    usleep(TIMEOUT_MS * 1000);
+
+    // Push second entry
+    // By this time first entry will be obsolete due to sleep above
+    uint64_t ts1 = gettsc();
+    err = timout_list_put(tolctx, &ts1);
+    assert(err == 0);
+
+    // Verify that the list returns only one entry and that's the second one
+    uint64_t buf[2] = { 0 };
+    err = timout_list_get(tolctx, buf, sizeof(buf));
+    assert(err == sizeof(ts1) && buf[0] == ts1);
+
+    // Destroy the timeout-list
+    timeout_list_fini(tolctx);
+
+    // Gets here only if above test passes
+    printf("PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
- cutils/time: a collection of time related C APIs
- cutils/list: inline doubly-linked list routines
    Courtesy: https://github.com/thecodeteam/dssd/blob/master/include/list.h
- cutils/timout_list: a list to maintain entries no older than given period

Testing
```
# basic build
$ make clobber && make -j $(nproc) && make -j $(nproc) ARCH=arm

# cutils/timeout_list is a data-structure that uses cutils/alloc, cutils/list, cutils/time and cutils/types libraries.
# Verified operation of all these libraries with a test for cutils/timeout_list
$ make -j $(nproc) libs/cutils/timeout_list/test
        [CC] objs.aarch64/libs/cutils/timeout_list/src/timeout_list.o
        [CC] objs.aarch64/libs/cutils/timeout_list/test/src/timeout_list_test.o
2 warnings generated.
        [AR] objs.aarch64/libs/cutils/timeout_list/libtimeout_list.a
     [CXXLD] objs.aarch64/libs/cutils/timeout_list/test/timeout_list_test
$ objs.aarch64/libs/cutils/timeout_list/test/timeout_list_test
PASSED
```