### PR TITLE
build: added target to verify build sanity of repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,19 @@ clobber: cleanall
 	@printf "%$(PCOL)s %s\n" "[RM]" "cscope.* tags"
 	$(Q)rm -f cscope.* tags
 
+#
+# Sanity check for repo's build
+#
+verify:
+	$(call run_verify_tgt,"o  Format check",format DRY_RUN=1)
+	$(call run_verify_tgt,"o  Clobber",clobber)
+	$(call run_verify_tgt,"o  Native tarball",tarball)
+	$(if $(filter $(TARGET_ARCH),x86_64), \
+		$(call run_verify_tgt,"o  ARCH=aarch64 tarball",tarball ARCH=aarch64),)
+	$(call run_verify_tgt,"o  ARCH=arm tarball",tarball ARCH=arm)
+	$(call run_verify_tgt,"o  Generate packages",pkg)
+	$(call run_verify_tgt,"o  Clobber",clobber)
+
 .DEFAULT_GOAL := all
 
 #
@@ -118,6 +131,7 @@ help:
 	@echo "     cleanall: remove all products for all targets architectues"
 	@echo "      clobber: cleanall + remove cscope/ctags"
 	@echo "       format: run 'clang-format' on new+modified files on this branch"
+	@echo "       verify: verify build sanity of repo"
 	@echo "         help: show this message"
 	@echo "<path>[:prod]: build all $(ARCH) products for <path> and subdirs below"
 	@echo "               if specified, build only the product "prod" in the <path>"

--- a/Makefile
+++ b/Makefile
@@ -104,15 +104,22 @@ clobber: cleanall
 #
 # Sanity check for repo's build
 #
+verify:: MKVERIFY_LOGS := /tmp/mkverify.log
 verify:
 	$(call run_verify_tgt,"o  Format check",format DRY_RUN=1)
 	$(call run_verify_tgt,"o  Clobber",clobber)
-	$(call run_verify_tgt,"o  Native tarball",tarball)
-	$(if $(filter $(TARGET_ARCH),x86_64), \
-		$(call run_verify_tgt,"o  ARCH=aarch64 tarball",tarball ARCH=aarch64),)
-	$(call run_verify_tgt,"o  ARCH=arm tarball",tarball ARCH=arm)
-	$(call run_verify_tgt,"o  Generate packages",pkg)
+	$(call run_verify_tgt,"o  Generate tarball (ARCH=$(TARGET_ARCH), native)",tarball)
+ifeq ($(TARGET_ARCH),x86_64)
+	$(call run_verify_tgt,"o  Generate tarball (ARCH=aarch64)",tarball ARCH=aarch64)
+endif
+	$(call run_verify_tgt,"o  Generate tarball (ARCH=arm)",tarball ARCH=arm)
+	$(call run_verify_tgt,"o  Generate packages (ARCH=$(TARGET_ARCH), native)",pkg)
+ifeq ($(TARGET_ARCH),x86_64)
+	$(call run_verify_tgt,"o  Generate packages (ARCH=aarch64)",pkg ARCH=aarch64)
+endif
+	$(call run_verify_tgt,"o  Generate packages (ARCH=arm)",pkg ARCH=arm)
 	$(call run_verify_tgt,"o  Clobber",clobber)
+	$(Q)rm -f $(MKVERIFY_LOGS)
 
 .DEFAULT_GOAL := all
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -469,6 +469,7 @@ define add_pkg_tgt
 $$(foreach pkg,$$(shell jq -r 'keys[]' $(PKG_JSON)),$$(eval $$(call pkg_tgt,$$(pkg))))
 endef
 
+
 #
 # Macro that executes build verification steps as enumerated under "verify" target
 #

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -473,6 +473,7 @@ endef
 # Macro that executes build verification steps as enumerated under "verify" target
 #
 define run_verify_tgt
-        @echo "$(1)"
-        $(Q)$(MAKE) -j $(CORES) --no-print-directory $(2) >/dev/null 2>&1
+        @echo $(1) | tee -a $(MKVERIFY_LOGS)
+        $(Q)$(MAKE) -j $(CORES) --no-print-directory $(2) >>$(MKVERIFY_LOGS) 2>&1 || \
+		{ cat $(MKVERIFY_LOGS) && rm -f $(MKVERIFY_LOGS) && false; }
 endef

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -468,3 +468,11 @@ endef
 define add_pkg_tgt
 $$(foreach pkg,$$(shell jq -r 'keys[]' $(PKG_JSON)),$$(eval $$(call pkg_tgt,$$(pkg))))
 endef
+
+#
+# Macro that executes build verification steps as enumerated under "verify" target
+#
+define run_verify_tgt
+        @echo "$(1)"
+        $(Q)$(MAKE) -j $(CORES) --no-print-directory $(2) >/dev/null 2>&1
+endef


### PR DESCRIPTION
About time.

Testing
```
# Output when no issues
$ make verify
o  Format check
o  Clobber
o  Generate tarball (ARCH=aarch64, native)
o  Generate tarball (ARCH=arm)
o  Generate packages (ARCH=aarch64, native)
o  Generate packages (ARCH=arm)
o  Clobber
```
```
# Output when issues (using an induced compile time error here)
# It essentially prints the redirected output of make targets till that failure point during verification
$ make verify
o  Format check
o  Clobber
o  Generate tarball (ARCH=aarch64, native)
o  Format check
Reformatting not needed.
o  Clobber
        [RM] objs.*
        [RM] cscope.* tags
o  Generate tarball (ARCH=aarch64, native)
       [TAR] objs.aarch64/libs/cutils/timeout_list/libtimeout_list-headers.tar
       [TAR] objs.aarch64/libs/cutils/types/libtypes-headers.tar
       [TAR] objs.firmware/firmware/libs/FreeRTOS/libfreertos-headers.tar
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/startup/startup_stm32f401xe.o
      [WEST] objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/zephyr/zephyr.elf
             Logs: objs.firmware/firmware/zephyr/hello_world/nucleo_f401re/build.log
       [TAR] objs.aarch64/libs/common/hello/libhello-headers.tar
       [TAR] objs.aarch64/libs/common/hello_cpp/libhello_cpp-headers.tar
       [TAR] objs.aarch64/libs/cutils/alloc/liballoc-headers.tar
       [TAR] objs.aarch64/libs/cutils/list/liblist-headers.tar
       [TAR] objs.aarch64/libs/cutils/time/libtime-headers.tar
       [TAR] objs.aarch64/libs/cutils/types/libtypes.tar
    [PROTOC] objs.aarch64/cmds/common/pb_example/proto/addressbook.pb.cc
        [CC] objs.firmware/firmware/libs/FreeRTOS/croutine.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/list.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/queue.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/event_groups.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/timers.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/tasks.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/stream_buffer.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/portable/GCC/ARM_CM4F/port.o
        [CC] objs.firmware/firmware/libs/FreeRTOS/portable/MemMang/heap_1.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/Utilities/STM32F4xx-Nucleo/stm32f4xx_nucleo.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/VL53L1X_api.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/VL53L1X_calibration.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/UltraLiteDriver/platform.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/platform_specific.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/main.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/system_stm32f4xx.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/stm32f4xx_it.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/src/syscalls.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_gpio.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_rcc_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_tim_ex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_i2c.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_dma2d.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/Legacy/stm32f4xx_hal_can.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_cortex.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_usart.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_tim.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_rcc.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_uart.o
        [CC] objs.firmware/firmware/nucleo/Lidar_Delivery/HAL_Driver/Src/stm32f4xx_hal_i2c_ex.o
        [CC] objs.aarch64/libs/common/hello/src/hello.o
       [CXX] objs.aarch64/libs/common/hello_cpp/src/hello.o
       [TAR] objs.aarch64/libs/cutils/alloc/liballoc.tar
       [TAR] objs.aarch64/libs/cutils/list/liblist.tar
       [TAR] objs.aarch64/libs/cutils/time/libtime.tar
        [CC] objs.aarch64/libs/cutils/timeout_list/src/timeout_list.o
2 warnings and 1 error generated.
Error while processing /home/popbot/tejas/stm-main/libs/cutils/timeout_list/src/timeout_list.c.
/home/popbot/tejas/stm-main/libs/cutils/timeout_list/src/timeout_list.c:108:15: error: expected ';' after return statement [clang-diagnostic-error]
    return off
              ^
              ;
make[1]: *** [/home/popbot/tejas/stm-main/buildtools/Makefile.clib:40: objs.aarch64/libs/cutils/timeout_list/src/timeout_list.o] Error 1
make[1]: *** Waiting for unfinished jobs....
4344 warnings generated.
make: *** [Makefile:111: verify] Error 1
```