### PR TITLE
cutils/ringbuf: thread-safe ring buffer APIs

### DIFF
--- a/libs/cutils/Makefile
+++ b/libs/cutils/Makefile
@@ -1,4 +1,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-SUBDIRS := alloc list time timeout_list types
+SUBDIRS := alloc list ringbuf time timeout_list types
 include $(shell git rev-parse --show-toplevel)/Makefile.defs
 $(eval $(call inc_subdir,$(THIS_DIR),$(SUBDIRS)))

--- a/libs/cutils/alloc/include/alloc.h
+++ b/libs/cutils/alloc/include/alloc.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libs/cutils/ringbuf/Makefile
+++ b/libs/cutils/ringbuf/Makefile
@@ -1,0 +1,23 @@
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+
+C_LIB := ringbuf
+
+# "includes"
+H_DIRS := include
+# "srcs"
+C_SRCS := src/ringbuf.c
+# "hdrs"
+I_HDRS := include/ringbuf.h
+
+# "deps"
+DEPEND := libs/cutils/alloc:alloc libs/cutils/types:types
+
+# strip_include_prefix
+STRIP_INC_PREFIX := include
+# include_prefix
+INC_PREFIX := cutils
+
+LFLAGS += -pthread
+
+include $(shell git rev-parse --show-toplevel)/Makefile.defs
+$(eval $(call inc_rule,clib,$(C_LIB)))

--- a/libs/cutils/ringbuf/include/ringbuf.h
+++ b/libs/cutils/ringbuf/include/ringbuf.h
@@ -1,0 +1,96 @@
+#ifndef CUTILS_RINGBUF_H
+#define CUTILS_RINGBUF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ringbuf rb_t; // ringbuf context handle
+
+/*
+ * @brief  Create a ring-buffer of fixed sized elements
+ *
+ * @param[in] base    Pointer to start of ring-buffer memory. If NULL then it
+ *                    will allocate memory of size (entsz * entnum) for the
+ *                    base buffer which will be freed when the rinbuf is
+ *                    destroyed. If not NULL then the pointer is treated as
+ *                    pre-allocated base buffer of same size
+ * @param[in] entsz   Size of each entry in the ringbuf
+ * @param[in] entnum  Number of entries in the ringbuf
+ *
+ * @return  Context handle for the ringbuf if success, NULL otherwise
+ */
+extern rb_t *rb_init(void *base, size_t entsz, size_t entnum);
+
+/*
+ * @brief  Destroy a previously created ring-buffer
+ *
+ * @param[in] rb  Context handle for a previously created ringbuf
+ */
+extern void rb_fini(rb_t *rb);
+
+/*
+ * @brief  Push an entry into the ring-buffer [thread-safe]
+ *         Blocks indefinitely if ring-buffer is full
+ *
+ * @param[in] rb   Context handle for a previously created ringbuf
+ * @param[in] src  Source entry buffer
+ *                 Buf size is assumed to be of same size ringbuf was
+ *                 initialized with
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or src is NULL)
+ */
+extern int rb_push(rb_t *rb, const void *src);
+
+/*
+ * @brief  Pop an entry from the ring-buffer [thread-safe]
+ *         Blocks indefinitely if ring-buffer is empty
+ *
+ * @param[in] rb   Context handle for a previously created ringbuf
+ * @param[in] dst  Destination entry buffer to save popped entry into
+ *                 Buf size is assumed to be of same size ringbuf was
+ *                 initialized with
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or dst is NULL)
+ */
+extern int rb_pop(rb_t *rb, void *dst);
+
+/*
+ * @brief  Push an entry into the ring-buffer [thread-safe]
+ *         Returns immediately if ring-buffer is full
+ *
+ * @param[in] rb   Context handle for a previously created ringbuf
+ * @param[in] src  Source entry buffer
+ *                 Buf size is assumed to be of same size ringbuf was
+ *                 initialized with
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or src is NULL)
+ *          EAGAIN  Ringbuf is full
+ */
+extern int rb_push_nb(rb_t *rb, const void *src);
+
+/*
+ * @brief  Pop an entry from the ring-buffer [thread-safe]
+ *         Returns immediately if ring-buffer is empty
+ *
+ * @param[in] rb   Context handle for a previously created ringbuf
+ * @param[in] dst  Destination entry buffer to save popped entry into
+ *                 Buf size is assumed to be of same size ringbuf was
+ *                 initialized with
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or dst is NULL)
+ *          EAGAIN  Ringbuf is empty
+ */
+extern int rb_pop_nb(rb_t *rb, void *dst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_RINGBUF_H

--- a/libs/cutils/ringbuf/include/ringbuf_priv.h
+++ b/libs/cutils/ringbuf/include/ringbuf_priv.h
@@ -1,0 +1,120 @@
+#ifndef CUTILS_RINGBUF_PRIV_H
+#define CUTILS_RINGBUF_PRIV_H
+
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <cutils/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ringbuf flags (for internal use only)
+enum {
+    RB_ALLOC = BIT(0), // base buffer is allocated in rb_init()
+    RB_NONBLOCK = BIT(1), // don't block if ringbuf is temporarily unavailable
+};
+typedef uint8_t rb_flag_t;
+
+// ringbuf end definition
+typedef struct {
+    uint16_t idx;
+    pthread_cond_t cond;
+} rb_end_t;
+
+// ringbuf context definition
+typedef struct ringbuf {
+    void *base;
+    size_t entsz;
+    size_t entnum;
+    rb_flag_t flags;
+    pthread_mutex_t mut;
+    rb_end_t wr;
+    rb_end_t rd;
+} rb_t;
+
+/*
+ * @brief  Check if ringbuf is empty
+ *
+ * @param[in] rb  Context handle for a previously created ringbuf
+ *
+ * @return  True ringbuf is empty, false otherwise
+ */
+static inline bool
+rb_empty(rb_t *rb)
+{
+    return rb->wr.idx == rb->rd.idx;
+}
+
+/*
+ * @brief  Check if ringbuf is full
+ *
+ * @param[in] rb  Context handle for a previously created ringbuf
+ *
+ * @return  True ringbuf is full, false otherwise
+ */
+static inline bool
+rb_full(rb_t *rb)
+{
+    return (rb->wr.idx + 1) % rb->entnum == rb->rd.idx;
+}
+
+/*
+ * @brief  Step ringbuf index by 1
+ *
+ * @param[in] rb  Context handle for a previously created ringbuf
+ * @param[in] e   Pointer to ringbuf read or write end
+ */
+static inline void
+rb_end_step(rb_t *rb, rb_end_t *e)
+{
+    e->idx = (e->idx + 1) % rb->entnum;
+}
+
+/*
+ * @brief  Fetch pointer reference to a ringbuf entry
+ *
+ * @param[in] rb  Context handle for a previously created ringbuf
+ * @param[in] e   Pointer to ringbuf read or write end
+ *
+ * @return  Pointer reference to the ringbuf entry
+ */
+static inline void *
+rb_ent(rb_t *rb, rb_end_t *e)
+{
+    return rb->base + e->idx * rb->entsz;
+}
+
+/*
+ * @brief  Worker function to push an entry into the ring-buffer [thread-safe]
+ *
+ * @param[in] rb        Context handle for a previously created ringbuf
+ * @param[in] src       Source entry buffer
+ * @param[in] rb_flags  ringbuf flags
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or src is NULL)
+ *          EAGAIN  Ringbuf is full
+ */
+static int rb_push_worker(rb_t *rb, const void *src, rb_flag_t rb_flags);
+
+/*
+ * @brief  Worker function to pop an entry from the ring-buffer [thread-safe]
+ *
+ * @param[in] rb        Context handle for a previously created ringbuf
+ * @param[in] dst       Destination entry buffer to save popped entry into
+ * @param[in] rb_flags  ringbuf flags
+ *
+ * @return  If success 0, errno otherwise
+ *          EINVAL  Invalid argument(s) (if rb or dst is NULL)
+ *          EAGAIN  Ringbuf is empty
+ */
+static int rb_pop_worker(rb_t *rb, void *dst, rb_flag_t rb_flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTILS_RINGBUF_PRIV_H

--- a/libs/cutils/ringbuf/src/ringbuf.c
+++ b/libs/cutils/ringbuf/src/ringbuf.c
@@ -1,0 +1,115 @@
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <cutils/alloc.h>
+#include "ringbuf.h"
+#include "ringbuf_priv.h"
+
+rb_t *
+rb_init(void *base, size_t entsz, size_t entnum)
+{
+    assert(entnum > 1); // number of entries (or ringbuf depth) must be >1
+
+    rb_t *rb = zmalloc(sizeof(rb_t));
+    if (!base) {
+        base = zmalloc(entsz * entnum);
+        rb->flags |= RB_ALLOC;
+    }
+    rb->base = base;
+    rb->entsz = entsz;
+    rb->entnum = entnum;
+
+    pthread_mutex_init(&rb->mut, NULL);
+    pthread_cond_init(&rb->wr.cond, NULL);
+    pthread_cond_init(&rb->rd.cond, NULL);
+
+    return rb;
+}
+
+void
+rb_fini(rb_t *rb)
+{
+    if (rb) {
+        pthread_mutex_lock(&rb->mut);
+        if (rb->base && (rb->flags & RB_ALLOC)) {
+            free(rb->base);
+        }
+        pthread_mutex_unlock(&rb->mut);
+        pthread_mutex_destroy(&rb->mut);
+        pthread_cond_destroy(&rb->wr.cond);
+        pthread_cond_destroy(&rb->rd.cond);
+        free(rb);
+    }
+}
+
+int
+rb_push_worker(rb_t *rb, const void *src, rb_flag_t rb_flags)
+{
+    if (!rb || !src) {
+        return EINVAL;
+    }
+    pthread_mutex_lock(&rb->mut);
+    while (rb_full(rb)) {
+        if (rb_flags & RB_NONBLOCK) {
+            pthread_mutex_unlock(&rb->mut);
+            return EAGAIN;
+        }
+        pthread_cond_wait(&rb->rd.cond, &rb->mut);
+    }
+
+    void *dst = rb_ent(rb, &rb->wr);
+    memcpy(dst, src, rb->entsz); // NOLINT
+    rb_end_step(rb, &rb->wr);
+    pthread_cond_signal(&rb->wr.cond);
+    pthread_mutex_unlock(&rb->mut);
+    return 0;
+}
+
+int
+rb_push(rb_t *rb, const void *src)
+{
+    return rb_push_worker(rb, src, 0);
+}
+
+int
+rb_push_nb(rb_t *rb, const void *src)
+{
+    return rb_push_worker(rb, src, RB_NONBLOCK);
+}
+
+int
+rb_pop_worker(rb_t *rb, void *dst, rb_flag_t rb_flags)
+{
+    if (!rb || !dst) {
+        return EINVAL;
+    }
+    pthread_mutex_lock(&rb->mut);
+    while (rb_empty(rb)) {
+        if (rb_flags & RB_NONBLOCK) {
+            pthread_mutex_unlock(&rb->mut);
+            return EAGAIN;
+        }
+        pthread_cond_wait(&rb->wr.cond, &rb->mut);
+    }
+
+    void *src = rb_ent(rb, &rb->rd);
+    memcpy(dst, src, rb->entsz); // NOLINT
+    rb_end_step(rb, &rb->rd);
+    pthread_cond_signal(&rb->rd.cond);
+    pthread_mutex_unlock(&rb->mut);
+    return 0;
+}
+
+int
+rb_pop(rb_t *rb, void *dst)
+{
+    return rb_pop_worker(rb, dst, 0);
+}
+
+int
+rb_pop_nb(rb_t *rb, void *dst)
+{
+    return rb_pop_worker(rb, dst, RB_NONBLOCK);
+}

--- a/libs/cutils/types/include/types.h
+++ b/libs/cutils/types/include/types.h
@@ -13,6 +13,8 @@ extern "C" {
 #define PTR_TO_ADDR(p) ((uintptr_t)(p))
 #define ADDR_TO_PTR(a) ((void *)(uintptr_t)(a))
 
+#define BIT(n) (1 << (n))
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Simple thread-safe ringbuf implementation based on Oracle's [Multithreaded Programming Guide](https://docs.oracle.com/cd/E19253-01/816-5137/816-5137.pdf).

Testing
```
TODO
```